### PR TITLE
Fix GUI spline sliders for sampling and gradient planners

### DIFF
--- a/mjpc/planners/gradient/planner.cc
+++ b/mjpc/planners/gradient/planner.cc
@@ -279,7 +279,7 @@ void GradientPlanner::OptimizePolicy(int horizon, ThreadPool& pool) {
   auto policy_update_start = std::chrono::steady_clock::now();
   {
     const std::unique_lock<std::shared_mutex> lock(mtx_);
-    policy.CopyFrom(candidate_policy[0], horizon);
+    policy.CopyParametersFrom(candidate_policy[0].parameters, candidate_policy[0].times);
   }
   policy_update_time +=
       std::chrono::duration_cast<std::chrono::microseconds>(

--- a/mjpc/planners/sampling/planner.cc
+++ b/mjpc/planners/sampling/planner.cc
@@ -176,8 +176,8 @@ void SamplingPlanner::OptimizePolicy(int horizon, ThreadPool& pool) {
   auto policy_update_start = std::chrono::steady_clock::now();
   {
     std::unique_lock<std::shared_mutex> lock(mtx_);
-    policy.CopyFrom(candidate_policy[winner],
-                    candidate_policy->num_spline_points);
+    policy.CopyParametersFrom(candidate_policy[winner].parameters,
+                    candidate_policy[winner].times);
   }
   policy_update_time +=
       std::chrono::duration_cast<std::chrono::microseconds>(


### PR DESCRIPTION
This fixes the bug where GUI sliders for the Sampling and Gradient planners don't update correctly. The fix is to only copy policy parameters instead of the entire policy.