### PR TITLE
Fix for sampling planner interpolation switching

### DIFF
--- a/mjpc/planners/sampling/planner.cc
+++ b/mjpc/planners/sampling/planner.cc
@@ -449,6 +449,9 @@ void SamplingPlanner::Rollouts(int num_trajectories, int horizon,
       // sample policy parameters
       s.SamplePolicy(i);
 
+      // set policy representation 
+      s.candidate_policy[i].representation = s.policy.representation;
+
       // ----- rollout sample policy ----- //
 
       // policy


### PR DESCRIPTION
Bug: Menu for Sampling planner option Spline would have no effect
Solution: Set candidate policy representation to current policy representation before rolling out trajectories in SamplingPlanner::Rollouts