### PR TITLE
Planner improvements

### DIFF
--- a/mjpc/agent.cc
+++ b/mjpc/agent.cc
@@ -161,6 +161,11 @@ void Agent::Plan(std::atomic<bool>& exitrequest,
       model_->opt.timestep = timestep_;
       model_->opt.integrator = integrator_;
 
+      // make contacts differentiable
+      // for (int i = 0; i < model->ngeom; i++) {
+      //   model->geom_solimp[mjNIMP * i] = 0.0;
+      // }
+      
       // set planning steps
       steps_ =
           mju_max(mju_min(horizon_ / timestep_ + 1, kMaxTrajectoryHorizon), 1);

--- a/mjpc/agent.cc
+++ b/mjpc/agent.cc
@@ -162,8 +162,8 @@ void Agent::Plan(std::atomic<bool>& exitrequest,
       model_->opt.integrator = integrator_;
 
       // make contacts differentiable
-      // for (int i = 0; i < model->ngeom; i++) {
-      //   model->geom_solimp[mjNIMP * i] = 0.0;
+      // for (int i = 0; i < model_->ngeom; i++) {
+      //   model_->geom_solimp[mjNIMP * i] = 0.0;
       // }
       
       // set planning steps

--- a/mjpc/planners/cost_derivatives.cc
+++ b/mjpc/planners/cost_derivatives.cc
@@ -181,11 +181,11 @@ void CostDerivatives::Compute(double* r, double* rx, double* ru,
                       DataAt(cd.cx, t * dim_state_derivative),
                       DataAt(cd.cx, t * dim_state_derivative),
                       dim_state_derivative, 1, dim_state_derivative);
-        mju_scl(cd.cxx_scratch_.data(), cd.cxx_scratch_.data(), risk * s,
+        mju_scl(DataAt(cd.cxx_scratch_, t * dim_state_derivative * dim_state_derivative), cd.cxx_scratch_.data(), risk * s,
                 dim_state_derivative * dim_state_derivative);
         mju_addTo(
             DataAt(cd.cxx, t * dim_state_derivative * dim_state_derivative),
-            cd.cxx_scratch_.data(),
+            DataAt(cd.cxx_scratch_, t * dim_state_derivative * dim_state_derivative),
             dim_state_derivative * dim_state_derivative);
 
         // cxu
@@ -193,23 +193,23 @@ void CostDerivatives::Compute(double* r, double* rx, double* ru,
                 DataAt(cd.cxu, t * dim_state_derivative * dim_action), s,
                 dim_state_derivative * dim_action);
         mju_mulMatMat(
-            cd.cxu_scratch_.data(), DataAt(cd.cx, t * dim_state_derivative),
+            DataAt(cd.cxu_scratch_, t * dim_state_derivative * dim_action), DataAt(cd.cx, t * dim_state_derivative),
             DataAt(cd.cu, t * dim_action), dim_state_derivative, 1, dim_action);
-        mju_scl(cd.cxu_scratch_.data(), cd.cxu_scratch_.data(), risk * s,
+        mju_scl(DataAt(cd.cxu_scratch_, t * dim_state_derivative * dim_action), DataAt(cd.cxu_scratch_, t * dim_state_derivative * dim_action), risk * s,
                 dim_state_derivative * dim_action);
         mju_addTo(DataAt(cd.cxu, t * dim_state_derivative * dim_action),
-                  cd.cxu_scratch_.data(), dim_state_derivative * dim_action);
+                  DataAt(cd.cxu_scratch_, t * dim_state_derivative * dim_action), dim_state_derivative * dim_action);
 
         // cuu
         mju_scl(DataAt(cd.cuu, t * dim_action * dim_action),
                 DataAt(cd.cuu, t * dim_action * dim_action), s,
                 dim_action * dim_action);
-        mju_mulMatMat(cd.cuu_scratch_.data(), DataAt(cd.cu, t * dim_action),
+        mju_mulMatMat(DataAt(cd.cuu_scratch_, t * dim_action * dim_action), DataAt(cd.cu, t * dim_action),
                       DataAt(cd.cu, t * dim_action), dim_action, 1, dim_action);
-        mju_scl(cd.cuu_scratch_.data(), cd.cuu_scratch_.data(), risk * s,
+        mju_scl(DataAt(cd.cuu_scratch_, t * dim_action * dim_action), DataAt(cd.cuu_scratch_, t * dim_action * dim_action), risk * s,
                 dim_action * dim_action);
         mju_addTo(DataAt(cd.cuu, t * dim_action * dim_action),
-                  cd.cuu_scratch_.data(), dim_action * dim_action);
+                  DataAt(cd.cuu_scratch_, t * dim_action * dim_action), dim_action * dim_action);
       });
     }
     pool.WaitCount(count_before + T);

--- a/mjpc/planners/cost_derivatives.cc
+++ b/mjpc/planners/cost_derivatives.cc
@@ -177,11 +177,11 @@ void CostDerivatives::Compute(double* r, double* rx, double* ru,
         mju_scl(DataAt(cd.cxx, t * dim_state_derivative * dim_state_derivative),
                 DataAt(cd.cxx, t * dim_state_derivative * dim_state_derivative),
                 s, dim_state_derivative * dim_state_derivative);
-        mju_mulMatMat(cd.cxx_scratch_.data(),
+        mju_mulMatMat(DataAt(cd.cxx_scratch_, t * dim_state_derivative * dim_state_derivative),
                       DataAt(cd.cx, t * dim_state_derivative),
                       DataAt(cd.cx, t * dim_state_derivative),
                       dim_state_derivative, 1, dim_state_derivative);
-        mju_scl(DataAt(cd.cxx_scratch_, t * dim_state_derivative * dim_state_derivative), cd.cxx_scratch_.data(), risk * s,
+        mju_scl(DataAt(cd.cxx_scratch_, t * dim_state_derivative * dim_state_derivative), DataAt(cd.cxx_scratch_, t * dim_state_derivative * dim_state_derivative), risk * s,
                 dim_state_derivative * dim_state_derivative);
         mju_addTo(
             DataAt(cd.cxx, t * dim_state_derivative * dim_state_derivative),

--- a/mjpc/planners/gradient/planner.h
+++ b/mjpc/planners/gradient/planner.h
@@ -67,8 +67,11 @@ class GradientPlanner : public Planner {
   void ActionFromPolicy(double* action, const double* state,
                         double time) override;
 
-  // update policy for current time
-  void UpdatePolicy(int horizon);
+  // resample nominal policy for current time
+  void ResamplePolicy(int horizon);
+
+  // compute candidate trajectories
+  void Rollouts(int horizon, ThreadPool& pool);
 
   // return trajectory with best total return
   const Trajectory* BestTrajectory() override;
@@ -82,9 +85,6 @@ class GradientPlanner : public Planner {
   // planner-specific plots
   void Plots(mjvFigure* fig_planner, mjvFigure* fig_timer,
              int planning) override;
-
-  // compute candidate trajectories
-  void Rollouts(int horizon, ThreadPool& pool);
 
   // ----- members ----- //
   mjModel* model;

--- a/mjpc/planners/gradient/policy.cc
+++ b/mjpc/planners/gradient/policy.cc
@@ -30,11 +30,6 @@ void GradientPolicy::Allocate(const mjModel* model, const Task& task,
   // model
   this->model = model;
 
-  // reference trajectory
-  trajectory.Initialize(model->nq + model->nv + model->na, model->nu,
-                        task.num_residual, kMaxTrajectoryHorizon);
-  trajectory.Allocate(kMaxTrajectoryHorizon);
-
   // action improvement
   k.resize(model->nu * kMaxTrajectoryHorizon);
 
@@ -59,7 +54,6 @@ void GradientPolicy::Allocate(const mjModel* model, const Task& task,
 
 // reset memory to zeros
 void GradientPolicy::Reset(int horizon) {
-  trajectory.Reset(horizon);
   std::fill(k.begin(), k.begin() + horizon * model->nu, 0.0);
 
   // parameters
@@ -98,9 +92,6 @@ void GradientPolicy::Action(double* action, const double* state,
 
 // copy policy
 void GradientPolicy::CopyFrom(const GradientPolicy& policy, int horizon) {
-  // reference
-  trajectory = policy.trajectory;
-
   // action improvement
   mju_copy(k.data(), policy.k.data(), horizon * model->nu);
 

--- a/mjpc/planners/gradient/policy.h
+++ b/mjpc/planners/gradient/policy.h
@@ -52,7 +52,6 @@ class GradientPolicy : public Policy {
   // ----- members ----- //
   const mjModel* model;
 
-  Trajectory trajectory;  // reference trajectory
   std::vector<double> k;  // action improvement
 
   std::vector<double> parameters;

--- a/mjpc/planners/ilqg/backward_pass.cc
+++ b/mjpc/planners/ilqg/backward_pass.cc
@@ -113,7 +113,7 @@ int iLQGBackwardPass::RiccatiStep(
   mju_addTo(Quut, cuut, m * m);
 
   //----- regularize ----- //
-  if (reg_type == kCostToGoRegularization) {
+  if (reg_type == kValueRegularization) {
     // regularize cost-to-go
     mju_copy(Vxx_reg, Wxx, n * n);
     for (int i = 0; i < n; i++) {

--- a/mjpc/planners/ilqg/backward_pass.cc
+++ b/mjpc/planners/ilqg/backward_pass.cc
@@ -37,7 +37,7 @@ void iLQGBackwardPass::Allocate(int dim_dstate, int dim_action, int T) {
   Quu.resize(dim_action * dim_action * (T - 1));
   Q_scratch.resize(
       10 *
-      (7 * dim_action + 2 * dim_action * dim_action + dim_dstate * dim_action +
+      (dim_dstate * dim_dstate + 7 * dim_action + 2 * dim_action * dim_action + dim_dstate * dim_action +
        3 * mju_max(dim_action, dim_dstate) * mju_max(dim_action, dim_dstate)));
 
   // regularization
@@ -71,11 +71,13 @@ int iLQGBackwardPass::RiccatiStep(
     const double *action, const double *action_limits, int reg_type,
     int limits) {
   int i, mmn = mju_max(m, n);
-  mjtNum *Quu_reg, *Qxu_reg, *tmp, *tmp2, *tmp3;
+  mjtNum *Vxx_reg, *Quu_reg, *Qxu_reg, *tmp, *tmp2, *tmp3;
 
   // allocate workspace variables
+  Vxx_reg = scratch;
+  scratch += n * n;
   Qxu_reg = scratch;
-  scratch += m * n;
+  scratch += n * m;
   Quu_reg = scratch;
   scratch += m * m;
   tmp = scratch;
@@ -111,14 +113,36 @@ int iLQGBackwardPass::RiccatiStep(
   mju_addTo(Quut, cuut, m * m);
 
   //----- regularize ----- //
-  mju_copy(Qxu_reg, Qxut, n * m);
-  mju_copy(Quu_reg, Quut, m * m);
+  if (reg_type == kCostToGoRegularization) {
+    // regularize cost-to-go
+    mju_copy(Vxx_reg, Wxx, n * n);
+    for (int i = 0; i < n; i++) {
+      Vxx_reg[n * i + i] += mu;
+    }
+
+    // Qxu_reg = cxut + At'*Vxx_reg*Bt
+    //    tmp  = At'*Vxx_reg
+    mju_mulMatTMat(tmp, At, Vxx_reg, n, n, n);
+    //    Qxu_reg = cxut  + tmp*Bt;
+    mju_mulMatMat(Qxu_reg, tmp, Bt, n, n, m);
+    mju_addTo(Qxu_reg, cxut, n * m);
+
+    // Quu_reg = cuut + Bt'*Vxx_reg*Bt;
+    //    tmp = Bt'*Vxx_reg
+    mju_mulMatTMat(tmp2, Bt, Vxx_reg, n, m, n);
+    mju_mulMatMat(Quu_reg, tmp2, Bt, m, n, m);
+    mju_addTo(Quu_reg, cuut, m * m);
+  } else {
+    mju_copy(Qxu_reg, Qxut, n * m);
+    mju_copy(Quu_reg, Quut, m * m);
+  }
+  
   if (mu) {
-    if (reg_type == 0) {
+    if (reg_type == kControlRegularization) {
       for (i = 0; i < m; i++) {
         Quu_reg[i * m + i] += mu;  // Quu_reg = Quut + mu*eye(m)
       }
-    } else if (reg_type == 1) {
+    } else if (reg_type == kStateControlRegularization) {
       mju_mulMatTMat(tmp, At, Bt, n, n, m);
       mju_addToScl(Qxu_reg, tmp, mu,
                    m * n);  // Qxu_reg = Qxut + mu*At'*Bt
@@ -135,11 +159,13 @@ int iLQGBackwardPass::RiccatiStep(
     // set problem
     mju_scl(boxqp.H.data(), Quu_reg, 1.0, m * m);
     mju_scl(boxqp.g.data(), Qut, 1.0, m);
+
     for (int i = 0; i < m; i++) {
       boxqp.lower[i] = action_limits[2 * i] - action[i];
       boxqp.upper[i] = action_limits[2 * i + 1] - action[i];
     }
-    // solve QP
+
+    // solve constrained quadratic program
     int mFree = mju_boxQP(boxqp.res.data(), boxqp.R.data(), boxqp.index.data(),
                           boxqp.H.data(), boxqp.g.data(), m, boxqp.lower.data(),
                           boxqp.upper.data());
@@ -166,6 +192,7 @@ int iLQGBackwardPass::RiccatiStep(
         Kt[j + n * boxqp.index[i]] = -tmp2[j * mFree + i];
       }
     }
+    
     // dut - solution to QP
     mju_copy(dut, boxqp.res.data(), m);
   } else {

--- a/mjpc/planners/ilqg/backward_pass.h
+++ b/mjpc/planners/ilqg/backward_pass.h
@@ -28,7 +28,7 @@ namespace mjpc {
 enum BackwardPassRegularization : int {
   kControlRegularization = 0,
   kStateControlRegularization,
-  kCostToGoRegularization
+  kValueRegularization
 };
 
 // data and methods to compute iLQG backward pass

--- a/mjpc/planners/ilqg/backward_pass.h
+++ b/mjpc/planners/ilqg/backward_pass.h
@@ -25,6 +25,12 @@
 
 namespace mjpc {
 
+enum BackwardPassRegularization : int {
+  kControlRegularization = 0,
+  kStateControlRegularization,
+  kCostToGoRegularization
+};
+
 // data and methods to compute iLQG backward pass
 class iLQGBackwardPass {
  public:

--- a/mjpc/planners/ilqg/planner.cc
+++ b/mjpc/planners/ilqg/planner.cc
@@ -358,7 +358,7 @@ void iLQGPlanner::GUI(mjUI& ui) {
       {mjITEM_SELECT, "Policy Interp.", 2, &policy.representation,
        "Zero\nLinear\nCubic"},
       {mjITEM_SELECT, "Reg. Type", 2, &settings.regularization_type,
-       "Control\nState-Control\nCost-To-Go\nNone"},
+       "Control\nFeedback\nValue\nNone"},
       {mjITEM_END}};
 
   // set number of trajectory slider limits

--- a/mjpc/planners/ilqg/planner.cc
+++ b/mjpc/planners/ilqg/planner.cc
@@ -156,7 +156,7 @@ void iLQGPlanner::OptimizePolicy(int horizon, ThreadPool& pool) {
 
   // rollout nominal policy
   this->NominalTrajectory(horizon);
-  
+
   // set previous best cost
   double c_prev = trajectory[0].total_return;
 
@@ -358,8 +358,8 @@ void iLQGPlanner::GUI(mjUI& ui) {
       {mjITEM_SLIDERINT, "Rollouts", 2, &num_trajectory, "0 1"},
       // {mjITEM_RADIO, "Action Lmt.", 2, &settings.action_limits, "Off\nOn"},
       // {mjITEM_SLIDERINT, "Iterations", 2, &settings.max_rollout, "1 25"},
-      // {mjITEM_SELECT, "Policy Interp.", 2, &policy.representation,
-      //  "Zero\nLinear\nCubic"},
+      {mjITEM_SELECT, "Policy Interp.", 2, &policy.representation,
+       "Zero\nLinear\nCubic"},
       {mjITEM_END}};
 
   // set number of trajectory slider limits

--- a/mjpc/planners/ilqg/planner.cc
+++ b/mjpc/planners/ilqg/planner.cc
@@ -135,6 +135,8 @@ void iLQGPlanner::SetState(State& state) {
 void iLQGPlanner::OptimizePolicy(int horizon, ThreadPool& pool) {
   ResizeMjData(model, pool.NumThreads());
   
+  policy.feedback = 0;
+
   // timers
   double nominal_time = 0.0;
   double model_derivative_time = 0.0;
@@ -153,6 +155,7 @@ void iLQGPlanner::OptimizePolicy(int horizon, ThreadPool& pool) {
   // copy nominal policy
   candidate_policy[0].CopyFrom(policy, horizon);
   candidate_policy[0].representation = policy.representation;
+  candidate_policy[0].feedback = 0;
 
   // rollout nominal policy
   this->NominalTrajectory(horizon);
@@ -235,6 +238,7 @@ void iLQGPlanner::OptimizePolicy(int horizon, ThreadPool& pool) {
     for (int i = 1; i < num_trajectory; i++) {
       candidate_policy[i].CopyFrom(candidate_policy[0], horizon);
       candidate_policy[i].representation = candidate_policy[0].representation;
+      candidate_policy[i].feedback = 0;
     }
 
     // improvement step sizes (log scaling)

--- a/mjpc/planners/ilqg/policy.cc
+++ b/mjpc/planners/ilqg/policy.cc
@@ -51,7 +51,7 @@ void iLQGPolicy::Allocate(const mjModel* model, const Task& task, int horizon) {
   state_interp.resize(model->nq + model->nv + model->na);
 
   // representation
-  representation = GetNumberOrDefault(1, model, "ilqg_representation");
+  representation = GetNumberOrDefault(1, model, "ilqg_representation");\
 }
 
 // reset memory to zeros
@@ -141,10 +141,10 @@ void iLQGPolicy::Action(double* action, const double* state,
   // ----- policy ----- //
 
   // add feedback
-  StateDiff(model, state_scratch.data(), state_interp.data(), state, 1.0);
-  mju_mulMatVec(action_scratch.data(), feedback_gain_scratch.data(),
-                state_scratch.data(), dim_action, dim_state_derivative);
-  mju_addTo(action, action_scratch.data(), dim_action);
+  // StateDiff(model, state_scratch.data(), state_interp.data(), state, 1.0);
+  // mju_mulMatVec(action_scratch.data(), feedback_gain_scratch.data(),
+  //               state_scratch.data(), dim_action, dim_state_derivative);
+  // mju_addTo(action, action_scratch.data(), dim_action);
 
   // Clamp controls
   Clamp(action, model->actuator_ctrlrange, dim_action);

--- a/mjpc/planners/ilqg/policy.cc
+++ b/mjpc/planners/ilqg/policy.cc
@@ -162,8 +162,6 @@ void iLQGPolicy::CopyFrom(const iLQGPolicy& policy, int horizon) {
   // action improvement
   mju_copy(action_improvement.data(), policy.action_improvement.data(),
            horizon * model->nu);
-
-  representation = policy.representation;
 }
 
 }  // namespace mjpc

--- a/mjpc/planners/ilqg/policy.cc
+++ b/mjpc/planners/ilqg/policy.cc
@@ -52,9 +52,6 @@ void iLQGPolicy::Allocate(const mjModel* model, const Task& task, int horizon) {
 
   // representation
   representation = GetNumberOrDefault(1, model, "ilqg_representation");
-
-  // feedback 
-  feedback = 0;
 }
 
 // reset memory to zeros

--- a/mjpc/planners/ilqg/policy.cc
+++ b/mjpc/planners/ilqg/policy.cc
@@ -51,7 +51,10 @@ void iLQGPolicy::Allocate(const mjModel* model, const Task& task, int horizon) {
   state_interp.resize(model->nq + model->nv + model->na);
 
   // representation
-  representation = GetNumberOrDefault(1, model, "ilqg_representation");\
+  representation = GetNumberOrDefault(1, model, "ilqg_representation");
+
+  // feedback 
+  feedback = 0;
 }
 
 // reset memory to zeros
@@ -141,11 +144,13 @@ void iLQGPolicy::Action(double* action, const double* state,
   // ----- policy ----- //
 
   // add feedback
-  // StateDiff(model, state_scratch.data(), state_interp.data(), state, 1.0);
-  // mju_mulMatVec(action_scratch.data(), feedback_gain_scratch.data(),
-  //               state_scratch.data(), dim_action, dim_state_derivative);
-  // mju_addTo(action, action_scratch.data(), dim_action);
-
+  if (feedback) {
+    StateDiff(model, state_scratch.data(), state_interp.data(), state, 1.0);
+    mju_mulMatVec(action_scratch.data(), feedback_gain_scratch.data(),
+                  state_scratch.data(), dim_action, dim_state_derivative);
+    mju_addTo(action, action_scratch.data(), dim_action);
+  }
+  
   // Clamp controls
   Clamp(action, model->actuator_ctrlrange, dim_action);
 }

--- a/mjpc/planners/ilqg/policy.cc
+++ b/mjpc/planners/ilqg/policy.cc
@@ -141,15 +141,12 @@ void iLQGPolicy::Action(double* action, const double* state,
                        dim_action * dim_state_derivative,
                        trajectory.horizon - 1);
   }
-  // ----- policy ----- //
 
   // add feedback
-  if (feedback) {
-    StateDiff(model, state_scratch.data(), state_interp.data(), state, 1.0);
-    mju_mulMatVec(action_scratch.data(), feedback_gain_scratch.data(),
-                  state_scratch.data(), dim_action, dim_state_derivative);
-    mju_addTo(action, action_scratch.data(), dim_action);
-  }
+  StateDiff(model, state_scratch.data(), state_interp.data(), state, 1.0);
+  mju_mulMatVec(action_scratch.data(), feedback_gain_scratch.data(),
+                state_scratch.data(), dim_action, dim_state_derivative);
+  mju_addTo(action, action_scratch.data(), dim_action);
   
   // Clamp controls
   Clamp(action, model->actuator_ctrlrange, dim_action);

--- a/mjpc/planners/ilqg/policy.h
+++ b/mjpc/planners/ilqg/policy.h
@@ -60,7 +60,6 @@ class iLQGPolicy : public Policy {
   mutable std::vector<double> feedback_gain_scratch;
   mutable std::vector<double> state_interp;
   int representation;
-  int feedback;
 };
 
 }  // namespace mjpc

--- a/mjpc/planners/ilqg/policy.h
+++ b/mjpc/planners/ilqg/policy.h
@@ -60,6 +60,7 @@ class iLQGPolicy : public Policy {
   mutable std::vector<double> feedback_gain_scratch;
   mutable std::vector<double> state_interp;
   int representation;
+  int feedback;
 };
 
 }  // namespace mjpc

--- a/mjpc/planners/ilqg/settings.h
+++ b/mjpc/planners/ilqg/settings.h
@@ -21,7 +21,7 @@ namespace mjpc {
 struct iLQGSettings {
   int max_rollout = 1;           // maximum number of planner iterations
   double min_step_size = 1.0e-3; // minimum step size for line search
-  double fd_tolerance = 1.0e-5;  // finite difference tolerance
+  double fd_tolerance = 1.0e-6;  // finite difference tolerance
   double fd_mode = 0;  // type of finite difference; 0: one-sided, 1: centered
   double min_regularization = 1.0e-6;  // minimum regularization value
   double max_regularization = 1.0e6;   // maximum regularization value

--- a/mjpc/planners/ilqg/settings.h
+++ b/mjpc/planners/ilqg/settings.h
@@ -25,7 +25,7 @@ struct iLQGSettings {
   double fd_mode = 0;  // type of finite difference; 0: one-sided, 1: centered
   double min_regularization = 1.0e-6;  // minimum regularization value
   double max_regularization = 1.0e6;   // maximum regularization value
-  int regularization_type = 0;         // 0: control; 1: state + control
+  int regularization_type = 2;         // 0: control; 1: feedback; 2: value; 3: none
   int max_regularization_iter =
       5;  // maximum number of regularization updates per iteration
   int action_limits = 0;  // flag

--- a/mjpc/planners/ilqg/settings.h
+++ b/mjpc/planners/ilqg/settings.h
@@ -25,7 +25,7 @@ struct iLQGSettings {
   double fd_mode = 0;  // type of finite difference; 0: one-sided, 1: centered
   double min_regularization = 1.0e-6;  // minimum regularization value
   double max_regularization = 1.0e6;   // maximum regularization value
-  int regularization_type = 1;         // 0: control; 1: state + control
+  int regularization_type = 0;         // 0: control; 1: state + control
   int max_regularization_iter =
       5;  // maximum number of regularization updates per iteration
   int action_limits = 0;  // flag

--- a/mjpc/planners/ilqg/settings.h
+++ b/mjpc/planners/ilqg/settings.h
@@ -28,7 +28,7 @@ struct iLQGSettings {
   int regularization_type = 1;         // 0: control; 1: state + control
   int max_regularization_iter =
       5;  // maximum number of regularization updates per iteration
-  int action_limits = 1;  // flag
+  int action_limits = 0;  // flag
   int verbose = 0;        // print optimizer info
 };
 

--- a/mjpc/planners/sampling/planner.h
+++ b/mjpc/planners/sampling/planner.h
@@ -73,8 +73,14 @@ class SamplingPlanner : public Planner {
   void ActionFromPolicy(double* action, const double* state,
                         double time) override;
 
-  // update policy via resampling
-  void UpdatePolicy(int horizon);
+  // resample nominal policy
+  void ResamplePolicy(int horizon);
+
+  // add noise to nominal policy
+  void AddNoiseToPolicy(int i);
+
+  // compute candidate trajectories
+  void Rollouts(int num_trajectories, int horizon, ThreadPool& pool);
 
   // return trajectory with best total return
   const Trajectory* BestTrajectory() override;
@@ -88,12 +94,6 @@ class SamplingPlanner : public Planner {
   // planner-specific plots
   void Plots(mjvFigure* fig_planner, mjvFigure* fig_timer,
              int planning) override;
-
-  // randomly sample policy (+)
-  void SamplePolicy(int i);
-
-  // compute candidate trajectories
-  void Rollouts(int num_trajectories, int horizon, ThreadPool& pool);
 
   // ----- members ----- //
   mjModel* model;

--- a/mjpc/simulate.cc
+++ b/mjpc/simulate.cc
@@ -479,7 +479,7 @@ void infotext(mj::Simulate* sim,
   solerr = mju_log10(mju_max(mjMINVAL, solerr));
 
   // prepare info text
-  mju::strcpy_arr(title, "Cost\nDoFs\nControls\nTime\nMemory");
+  mju::strcpy_arr(title, "Objective\nDoFs\nControls\nTime\nMemory");
   mju::sprintf_arr(content,
                    "%.3f\n%d\n%d\n%-9.3f\n%.2g of %s",
                    sim->agent.ActivePlanner().BestTrajectory()->total_return,

--- a/mjpc/tasks/humanoid/humanoid.cc
+++ b/mjpc/tasks/humanoid/humanoid.cc
@@ -35,14 +35,17 @@ void Humanoid::ResidualStand(const double* parameters, const mjModel* model,
                              const mjData* data, double* residual) {
     // ----- action ----- //
   mju_copy(residual, data->ctrl, model->nu);
+
   // ----- COM feet xy error ----- //
   // center of mass position
   double* com_position = mjpc::SensorByName(model, data, "torso_subtreecom");
+
   // feet sensor positions
   double* f1_position = mjpc::SensorByName(model, data, "sp0");
   double* f2_position = mjpc::SensorByName(model, data, "sp1");
   double* f3_position = mjpc::SensorByName(model, data, "sp2");
   double* f4_position = mjpc::SensorByName(model, data, "sp3");
+
   // average feet xy position
   double fxy_avg[2] = {0.0};
   mju_addTo(fxy_avg, f1_position, 2);
@@ -50,26 +53,31 @@ void Humanoid::ResidualStand(const double* parameters, const mjModel* model,
   mju_addTo(fxy_avg, f3_position, 2);
   mju_addTo(fxy_avg, f4_position, 2);
   mju_scl(fxy_avg, fxy_avg, 0.25, 2);
+
   // center of mass and average feet position xy error
   mju_subFrom(fxy_avg, com_position, 2);
   double com_feet_distance = mju_norm(fxy_avg, 2);
   residual[model->nu] = com_feet_distance;
+
   // ----- torso COM xy error ----- //
   double* torso_position = mjpc::SensorByName(model, data, "torso_position");
   double torso_com_error[2];
   mju_sub(torso_com_error, torso_position, com_position, 2);
   double torso_com_distance = mju_norm(torso_com_error, 2);
   residual[model->nu + 1] = torso_com_distance;
+
   // ----- head feet vertical error ----- //
   double* head_position = mjpc::SensorByName(model, data, "head_position");
   double head_feet_error =
       head_position[2] - 0.25 * (f1_position[2] + f2_position[2] +
                                  f3_position[2] + f4_position[2]);
   residual[model->nu + 2] = head_feet_error - parameters[0];
+
   // ----- COM xy velocity ----- //
   double* com_velocity =
       mjpc::SensorByName(model, data, "torso_subtreelinvel");
   mju_copy(residual + model->nu + 3, com_velocity, 2);
+  
   // ----- joint velocity ----- //
   mju_copy(residual + model->nu + 5, data->qvel, model->nv);
 

--- a/mjpc/tasks/humanoid/humanoid.cc
+++ b/mjpc/tasks/humanoid/humanoid.cc
@@ -33,30 +33,16 @@ namespace mjpc {
 // ----------------------------------------------------------------
 void Humanoid::ResidualStand(const double* parameters, const mjModel* model,
                              const mjData* data, double* residual) {
-  int counter = 0;
-
-  // ----- Height: head feet vertical error ----- //
-
+    // ----- action ----- //
+  mju_copy(residual, data->ctrl, model->nu);
+  // ----- COM feet xy error ----- //
+  // center of mass position
+  double* com_position = mjpc::SensorByName(model, data, "torso_subtreecom");
   // feet sensor positions
   double* f1_position = mjpc::SensorByName(model, data, "sp0");
   double* f2_position = mjpc::SensorByName(model, data, "sp1");
   double* f3_position = mjpc::SensorByName(model, data, "sp2");
   double* f4_position = mjpc::SensorByName(model, data, "sp3");
-  double* head_position = mjpc::SensorByName(model, data, "head_position");
-  double head_feet_error =
-      head_position[2] - 0.25 * (f1_position[2] + f2_position[2] +
-                                 f3_position[2] + f4_position[2]);
-  residual[counter++] = head_feet_error - parameters[0];
-
-  // ----- Balance: CoM-feet xy error ----- //
-
-  // capture point
-  double* com_position = mjpc::SensorByName(model, data, "torso_subtreecom");
-  double* com_velocity = mjpc::SensorByName(model, data, "torso_subtreelinvel");
-  double kFallTime = 0.2;
-  double capture_point[3] = {com_position[0], com_position[1], com_position[2]};
-  mju_addToScl3(capture_point, com_velocity, kFallTime);
-
   // average feet xy position
   double fxy_avg[2] = {0.0};
   mju_addTo(fxy_avg, f1_position, 2);
@@ -64,35 +50,41 @@ void Humanoid::ResidualStand(const double* parameters, const mjModel* model,
   mju_addTo(fxy_avg, f3_position, 2);
   mju_addTo(fxy_avg, f4_position, 2);
   mju_scl(fxy_avg, fxy_avg, 0.25, 2);
-
-  mju_subFrom(fxy_avg, capture_point, 2);
+  // center of mass and average feet position xy error
+  mju_subFrom(fxy_avg, com_position, 2);
   double com_feet_distance = mju_norm(fxy_avg, 2);
-  residual[counter++] = com_feet_distance;
-
-  // ----- COM xy velocity should be 0 ----- //
-  mju_copy(&residual[counter], com_velocity, 2);
-  counter += 2;
-
+  residual[model->nu] = com_feet_distance;
+  // ----- torso COM xy error ----- //
+  double* torso_position = mjpc::SensorByName(model, data, "torso_position");
+  double torso_com_error[2];
+  mju_sub(torso_com_error, torso_position, com_position, 2);
+  double torso_com_distance = mju_norm(torso_com_error, 2);
+  residual[model->nu + 1] = torso_com_distance;
+  // ----- head feet vertical error ----- //
+  double* head_position = mjpc::SensorByName(model, data, "head_position");
+  double head_feet_error =
+      head_position[2] - 0.25 * (f1_position[2] + f2_position[2] +
+                                 f3_position[2] + f4_position[2]);
+  residual[model->nu + 2] = head_feet_error - parameters[0];
+  // ----- COM xy velocity ----- //
+  double* com_velocity =
+      mjpc::SensorByName(model, data, "torso_subtreelinvel");
+  mju_copy(residual + model->nu + 3, com_velocity, 2);
   // ----- joint velocity ----- //
-  mju_copy(residual + counter, data->qvel, model->nv);
-  counter += model->nv;
-
-  // ----- action ----- //
-  mju_copy(&residual[counter], data->ctrl, model->nu);
-  counter += model->nu;
+  mju_copy(residual + model->nu + 5, data->qvel, model->nv);
 
   // sensor dim sanity check
   // TODO: use this pattern everywhere and make this a utility function
-  int user_sensor_dim = 0;
-  for (int i=0; i < model->nsensor; i++) {
-    if (model->sensor_type[i] == mjSENS_USER) {
-      user_sensor_dim += model->sensor_dim[i];
-    }
-  }
-  if (user_sensor_dim != counter) {
-    mju_error_i("mismatch between total user-sensor dimension "
-                "and actual length of residual %d", counter);
-  }
+  // int user_sensor_dim = 0;
+  // for (int i=0; i < model->nsensor; i++) {
+  //   if (model->sensor_type[i] == mjSENS_USER) {
+  //     user_sensor_dim += model->sensor_dim[i];
+  //   }
+  // }
+  // if (user_sensor_dim != counter) {
+  //   mju_error_i("mismatch between total user-sensor dimension "
+  //               "and actual length of residual %d", counter);
+  // }
 }
 
 }  // namespace mjpc

--- a/mjpc/tasks/humanoid/humanoid.cc
+++ b/mjpc/tasks/humanoid/humanoid.cc
@@ -33,18 +33,29 @@ namespace mjpc {
 // ----------------------------------------------------------------
 void Humanoid::ResidualStand(const double* parameters, const mjModel* model,
                              const mjData* data, double* residual) {
-    // ----- action ----- //
-  mju_copy(residual, data->ctrl, model->nu);
+  int counter = 0;
 
-  // ----- COM feet xy error ----- //
-  // center of mass position
-  double* com_position = mjpc::SensorByName(model, data, "torso_subtreecom");
+  // ----- Height: head feet vertical error ----- //
 
   // feet sensor positions
   double* f1_position = mjpc::SensorByName(model, data, "sp0");
   double* f2_position = mjpc::SensorByName(model, data, "sp1");
   double* f3_position = mjpc::SensorByName(model, data, "sp2");
   double* f4_position = mjpc::SensorByName(model, data, "sp3");
+  double* head_position = mjpc::SensorByName(model, data, "head_position");
+  double head_feet_error =
+      head_position[2] - 0.25 * (f1_position[2] + f2_position[2] +
+                                 f3_position[2] + f4_position[2]);
+  residual[counter++] = head_feet_error - parameters[0];
+
+  // ----- Balance: CoM-feet xy error ----- //
+
+  // capture point
+  double* com_position = mjpc::SensorByName(model, data, "torso_subtreecom");
+  double* com_velocity = mjpc::SensorByName(model, data, "torso_subtreelinvel");
+  double kFallTime = 0.2;
+  double capture_point[3] = {com_position[0], com_position[1], com_position[2]};
+  mju_addToScl3(capture_point, com_velocity, kFallTime);
 
   // average feet xy position
   double fxy_avg[2] = {0.0};
@@ -54,45 +65,34 @@ void Humanoid::ResidualStand(const double* parameters, const mjModel* model,
   mju_addTo(fxy_avg, f4_position, 2);
   mju_scl(fxy_avg, fxy_avg, 0.25, 2);
 
-  // center of mass and average feet position xy error
-  mju_subFrom(fxy_avg, com_position, 2);
+  mju_subFrom(fxy_avg, capture_point, 2);
   double com_feet_distance = mju_norm(fxy_avg, 2);
-  residual[model->nu] = com_feet_distance;
+  residual[counter++] = com_feet_distance;
 
-  // ----- torso COM xy error ----- //
-  double* torso_position = mjpc::SensorByName(model, data, "torso_position");
-  double torso_com_error[2];
-  mju_sub(torso_com_error, torso_position, com_position, 2);
-  double torso_com_distance = mju_norm(torso_com_error, 2);
-  residual[model->nu + 1] = torso_com_distance;
+  // ----- COM xy velocity should be 0 ----- //
+  mju_copy(&residual[counter], com_velocity, 2);
+  counter += 2;
 
-  // ----- head feet vertical error ----- //
-  double* head_position = mjpc::SensorByName(model, data, "head_position");
-  double head_feet_error =
-      head_position[2] - 0.25 * (f1_position[2] + f2_position[2] +
-                                 f3_position[2] + f4_position[2]);
-  residual[model->nu + 2] = head_feet_error - parameters[0];
-
-  // ----- COM xy velocity ----- //
-  double* com_velocity =
-      mjpc::SensorByName(model, data, "torso_subtreelinvel");
-  mju_copy(residual + model->nu + 3, com_velocity, 2);
-  
   // ----- joint velocity ----- //
-  mju_copy(residual + model->nu + 5, data->qvel, model->nv);
+  mju_copy(residual + counter, data->qvel, model->nv);
+  counter += model->nv;
+
+  // ----- action ----- //
+  mju_copy(&residual[counter], data->ctrl, model->nu);
+  counter += model->nu;
 
   // sensor dim sanity check
   // TODO: use this pattern everywhere and make this a utility function
-  // int user_sensor_dim = 0;
-  // for (int i=0; i < model->nsensor; i++) {
-  //   if (model->sensor_type[i] == mjSENS_USER) {
-  //     user_sensor_dim += model->sensor_dim[i];
-  //   }
-  // }
-  // if (user_sensor_dim != counter) {
-  //   mju_error_i("mismatch between total user-sensor dimension "
-  //               "and actual length of residual %d", counter);
-  // }
+  int user_sensor_dim = 0;
+  for (int i=0; i < model->nsensor; i++) {
+    if (model->sensor_type[i] == mjSENS_USER) {
+      user_sensor_dim += model->sensor_dim[i];
+    }
+  }
+  if (user_sensor_dim != counter) {
+    mju_error_i("mismatch between total user-sensor dimension "
+                "and actual length of residual %d", counter);
+  }
 }
 
 }  // namespace mjpc

--- a/mjpc/tasks/humanoid/task_stand.xml
+++ b/mjpc/tasks/humanoid/task_stand.xml
@@ -12,7 +12,7 @@
     <numeric name="residual_Height Goal" data="1.4 0.0 2.0" />
   </custom>
   <sensor>
-    <user name="Control" needstage="acc" dim="21" user="3 0.025 0.0 1.0 0.3" />
+    <user name="Control" needstage="acc" dim="21" user="3 0.1 0.0 1.0 0.3" />
     <user name="COM-Feet" needstage="acc" dim="1" user="6 100.0 0.0 1000.0 0.1" />
     <user name="Torso-COM" needstage="acc" dim="1" user="6 1.0 0.0 10.0 0.1" />
     <user name="Head-Feet" needstage="acc" dim="1" user="6 100.0 0.0 1000.0 0.1" />

--- a/mjpc/tasks/humanoid/task_stand.xml
+++ b/mjpc/tasks/humanoid/task_stand.xml
@@ -1,7 +1,8 @@
-<mujoco model="Humanoid Locomotion">
+<mujoco model="Humanoid">
   <include file="../common.xml"/>
   <include file="humanoid.xml" />
   <size memory="400K"/>
+
   <custom>
     <numeric name="agent_planner" data="0" />
     <numeric name="agent_horizon" data="0.35" />
@@ -9,15 +10,15 @@
     <numeric name="sampling_spline_points" data="3" />
     <numeric name="sampling_exploration" data="0.05" />
     <numeric name="gradient_spline_points" data="5" />
-    <numeric name="residual_Height Goal" data="1.4 0.0 2.0" />
+    <numeric name="residual_Height Goal" data="1.4 0.0 1.5" />
   </custom>
+
   <sensor>
-    <user name="Control" needstage="acc" dim="21" user="3 0.1 0.0 1.0 0.3" />
-    <user name="COM-Feet" needstage="acc" dim="1" user="6 100.0 0.0 1000.0 0.1" />
-    <user name="Torso-COM" needstage="acc" dim="1" user="6 1.0 0.0 10.0 0.1" />
-    <user name="Head-Feet" needstage="acc" dim="1" user="6 100.0 0.0 1000.0 0.1" />
-    <user name="COM Vel." needstage="acc" dim="2" user="0 10.0 0.0 100.0" />
-    <user name="Jnt. Vel." needstage="acc" dim="27" user="0 0.01 0.0 1.0" />
+    <user name="Height" needstage="acc" dim="1" user="6 100.0 0.0 100.0 0.1" />
+    <user name="Balance" needstage="acc" dim="1" user="6 50.0 0.0 100.0 0.1" />
+    <user name="CoM Vel." needstage="acc" dim="2" user="0 10.0 0.0 100.0" />
+    <user name="Joint Vel." needstage="acc" dim="27" user="0 0.01 0.0 0.1" />
+    <user name="Control" needstage="acc" dim="21" user="3 0.025 0.0 0.1 0.3" />
     <framepos name="trace" objtype="body" objname="torso"/>
     <framepos name="torso_position" objtype="body" objname="torso"/>
     <framepos name="head_position" objtype="body" objname="head"/>
@@ -30,5 +31,7 @@
     <framepos name="sp1" objtype="site" objname="sp1"/>
     <framepos name="sp2" objtype="site" objname="sp2"/>
     <framepos name="sp3" objtype="site" objname="sp3"/>
+    <subtreelinvel name="foot_right_vel" body="foot_right"/>
+    <subtreelinvel name="foot_left_vel" body="foot_left"/>
   </sensor>
 </mujoco>

--- a/mjpc/tasks/humanoid/task_stand.xml
+++ b/mjpc/tasks/humanoid/task_stand.xml
@@ -1,8 +1,7 @@
-<mujoco model="Humanoid">
+<mujoco model="Humanoid Locomotion">
   <include file="../common.xml"/>
   <include file="humanoid.xml" />
   <size memory="400K"/>
-
   <custom>
     <numeric name="agent_planner" data="0" />
     <numeric name="agent_horizon" data="0.35" />
@@ -10,15 +9,15 @@
     <numeric name="sampling_spline_points" data="3" />
     <numeric name="sampling_exploration" data="0.05" />
     <numeric name="gradient_spline_points" data="5" />
-    <numeric name="residual_Height Goal" data="1.4 0.0 1.5" />
+    <numeric name="residual_Height Goal" data="1.4 0.0 2.0" />
   </custom>
-
   <sensor>
-    <user name="Height" needstage="acc" dim="1" user="6 100.0 0.0 100.0 0.1" />
-    <user name="Balance" needstage="acc" dim="1" user="1 50.0 0.0 100.0 0.05 1" />
-    <user name="CoM Vel." needstage="acc" dim="2" user="0 10.0 0.0 100.0" />
-    <user name="Joint Vel." needstage="acc" dim="27" user="0 0.01 0.0 0.1" />
-    <user name="Control" needstage="acc" dim="21" user="3 0.025 0.0 0.1 0.3" />
+    <user name="Control" needstage="acc" dim="21" user="3 0.025 0.0 1.0 0.3" />
+    <user name="COM-Feet" needstage="acc" dim="1" user="6 100.0 0.0 1000.0 0.1" />
+    <user name="Torso-COM" needstage="acc" dim="1" user="6 1.0 0.0 10.0 0.1" />
+    <user name="Head-Feet" needstage="acc" dim="1" user="6 100.0 0.0 1000.0 0.1" />
+    <user name="COM Vel." needstage="acc" dim="2" user="0 10.0 0.0 100.0" />
+    <user name="Jnt. Vel." needstage="acc" dim="27" user="0 0.01 0.0 1.0" />
     <framepos name="trace" objtype="body" objname="torso"/>
     <framepos name="torso_position" objtype="body" objname="torso"/>
     <framepos name="head_position" objtype="body" objname="head"/>
@@ -31,7 +30,5 @@
     <framepos name="sp1" objtype="site" objname="sp1"/>
     <framepos name="sp2" objtype="site" objname="sp2"/>
     <framepos name="sp3" objtype="site" objname="sp3"/>
-    <subtreelinvel name="foot_right_vel" body="foot_right"/>
-    <subtreelinvel name="foot_left_vel" body="foot_left"/>
   </sensor>
 </mujoco>

--- a/mjpc/tasks/walker/task.xml
+++ b/mjpc/tasks/walker/task.xml
@@ -16,7 +16,7 @@
   </custom>
 
   <sensor>
-    <user name="Control" needstage="acc" dim="6" user="0 1.0e-5 0.0 1.0" />
+    <user name="Control" needstage="acc" dim="6" user="0 0.1 0.0 1.0" />
     <user name="Height" needstage="acc" dim="1" user="0 10.0 0.0 10.0" />
     <user name="Rotation" needstage="acc" dim="1" user="0 3.0 0.0 5.0" />
     <user name="Speed" needstage="acc" dim="1" user="0 1.0 0.0 1.0" />

--- a/mjpc/test/agent/CMakeLists.txt
+++ b/mjpc/test/agent/CMakeLists.txt
@@ -18,6 +18,9 @@ target_link_libraries(agent_test load gmock)
 test(cost_derivatives_test)
 target_link_libraries(cost_derivatives_test finite_difference gmock)
 
+test(norm_test)
+target_link_libraries(norm_test finite_difference gmock)
+
 test(rollout_test)
 target_link_libraries(rollout_test load gmock)
 

--- a/mjpc/test/gradient_planner/gradient_planner_test.cc
+++ b/mjpc/test/gradient_planner/gradient_planner_test.cc
@@ -94,27 +94,23 @@ TEST(GradientPlannerTest, Particle) {
   }
 
   // test final state
-  EXPECT_NEAR(planner.candidate_policy[0]
-                  .trajectory.states[(steps - 1) * (model->nq + model->nv)],
+  EXPECT_NEAR(planner.trajectory[planner.winner].states[(steps - 1) * (model->nq + model->nv)],
               state.mocap()[0], 1.0e-2);
-  EXPECT_NEAR(planner.candidate_policy[0]
-                  .trajectory.states[(steps - 1) * (model->nq + model->nv) + 1],
+  EXPECT_NEAR(planner.trajectory[planner.winner].states[(steps - 1) * (model->nq + model->nv) + 1],
               state.mocap()[1], 1.0e-2);
-  EXPECT_NEAR(planner.candidate_policy[0]
-                  .trajectory.states[(steps - 1) * (model->nq + model->nv) + 2],
+  EXPECT_NEAR(planner.trajectory[planner.winner].states[(steps - 1) * (model->nq + model->nv) + 2],
               0.0, 1.0e-1);
-  EXPECT_NEAR(planner.candidate_policy[0]
-                  .trajectory.states[(steps - 1) * (model->nq + model->nv) + 3],
+  EXPECT_NEAR(planner.trajectory[planner.winner].states[(steps - 1) * (model->nq + model->nv) + 3],
               0.0, 1.0e-1);
 
   // test action limits
   for (int t = 0; t < steps - 1; t++) {
     for (int i = 0; i < model->nu; i++) {
       EXPECT_LE(
-          planner.candidate_policy[0].trajectory.actions[t * model->nu + i],
+          planner.trajectory[planner.winner].actions[t * model->nu + i],
           model->actuator_ctrlrange[2 * i + 1]);
       EXPECT_GE(
-          planner.candidate_policy[0].trajectory.actions[t * model->nu + i],
+          planner.trajectory[planner.winner].actions[t * model->nu + i],
           model->actuator_ctrlrange[2 * i]);
     }
   }

--- a/mjpc/test/gradient_planner/gradient_test.cc
+++ b/mjpc/test/gradient_planner/gradient_test.cc
@@ -58,8 +58,6 @@ TEST(GradientTest, Gradient) {
 
   // // policy
   GradientPolicy p;
-  p.trajectory.Initialize(n, m, 0, T);
-  p.trajectory.Allocate(T);
   p.k.resize(m * T);
 
   // model derivatives


### PR DESCRIPTION
A number of improvements and fixes to the planners:

iLQG
- initial copy of nominal policy to prevent threading conflicts with policy scratch space
- fix backward pass initialization (ie, remove incorrect trajectory copy)
- cost-to-go regularization option
- regularization type GUI menu option
- default regularization type setting changed to control

Gradient 
- initial copy of nominal policy to prevent threading conflicts/locks
- remove `Trajectory` from policy

Sampling
- initial copy of nominal policy to prevent threading conflicts/locks
- remove Uniform sampling
- simplify noise sampling function
- more descriptive naming for functions 

Fix for `CostDerivatives::Compute`
- time shift scratch spaces to prevent threading conflicts

Rename infotext `Cost` -> `Objective`

Modification to humanoid stand task to achieve more stable behaviour: change balance norm 1 -> 6

Include `norm_test`
