### PR TITLE
Visualize multiple traces

### DIFF
--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -177,7 +177,7 @@ As mentioned above, the cost is a sum of terms, each computed as a (scalar) norm
 - `weight_lower_bound`, `weight_upper_bound`: Real numbers specifying lower and upper bounds on $\text{weight}$, used for configuring the GUI slider.
 - `parameters`: Optional real numbers specifying $\text{norm}$-specific parameters, see [norm implementation](../mjpc/norm.cc).
 
-The user sensors defining the residuals should be declared first. Therefore, all sensors should be defined in the task file. After the cost terms are specified, more sensors can be defined to specify the task, e.g., when the residual implementation relies on reading a sensor value. If a sensor named `trace` exists, the GUI will use it to draw the traces of the tentative and nominal trajectories.
+The user sensors defining the residuals should be declared first. Therefore, all sensors should be defined in the task file. After the cost terms are specified, more sensors can be defined to specify the task, e.g., when the residual implementation relies on reading a sensor value. If a sensor named `trace%i` exists, the GUI will use it to draw the traces of the tentative and nominal trajectories.
 
 Computing the residual vectors is specified via a C++ function with the following interface:
 
@@ -204,7 +204,7 @@ As an example, consider these snippets specifying the Swimmer task:
 <sensor>
   <user name="Control" dim="5" user="0 0.1 0 0.1" />
   <user name="Distance" dim="2" user="2 30 0 100 0.04" />
-  <framepos name="trace" objtype="geom" objname="nose"/>
+  <framepos name="trace0" objtype="geom" objname="nose"/>
   <framepos name="nose" objtype="geom" objname="nose"/>
   <framepos name="target" objtype="body" objname="target"/>
 </sensor>

--- a/mjpc/agent.cc
+++ b/mjpc/agent.cc
@@ -120,7 +120,7 @@ void Agent::Allocate() {
 
   // cost
   residual_.resize(task_.num_residual);
-  terms_.resize(task_.num_norms * kMaxTrajectoryHorizon);
+  terms_.resize(task_.num_cost * kMaxTrajectoryHorizon);
 }
 
 // reset data, settings, planners, states
@@ -242,23 +242,26 @@ void Agent::ModifyScene(mjvScene* scn) {
 
   // policy
   for (int i = 0; i < winner->horizon - 1; i++) {
-    // check max geoms
-    if (scn->ngeom >= scn->maxgeom) {
-      continue;
+    for (int j = 0; j < task_.num_trace; j++) {
+      // check max geoms
+      if (scn->ngeom >= scn->maxgeom) {
+        printf("max geom!!!\n");
+        continue;
+      }
+
+      // initialize geometry
+      mjv_initGeom(&scn->geoms[scn->ngeom], mjGEOM_CAPSULE, zero3, zero3, zero9,
+                  color);
+
+      // make geometry
+      mjv_makeConnector(&scn->geoms[scn->ngeom], mjGEOM_CAPSULE, width,
+                        winner->trace[3 * task_.num_trace * i + 3 * j], winner->trace[3 * task_.num_trace * i + 1 + 3 * j],
+                        winner->trace[3 * task_.num_trace * i + 2 + 3 * j], winner->trace[3 * task_.num_trace * (i + 1) + 3 * j],
+                        winner->trace[3 * task_.num_trace * (i + 1) + 1 + 3 * j],
+                        winner->trace[3 * task_.num_trace * (i + 1) + 2 + 3 * j]);
+      // increment number of geometries
+      scn->ngeom += 1;
     }
-
-    // initialize geometry
-    mjv_initGeom(&scn->geoms[scn->ngeom], mjGEOM_CAPSULE, zero3, zero3, zero9,
-                 color);
-
-    // make geometry
-    mjv_makeConnector(&scn->geoms[scn->ngeom], mjGEOM_CAPSULE, width,
-                      winner->trace[3 * i], winner->trace[3 * i + 1],
-                      winner->trace[3 * i + 2], winner->trace[3 * (i + 1)],
-                      winner->trace[3 * (i + 1) + 1],
-                      winner->trace[3 * (i + 1) + 2]);
-    // increment number of geometries
-    scn->ngeom += 1;
   }
 
   // sample traces
@@ -280,9 +283,9 @@ void Agent::Gui(mjUI& ui) {
   mjui_add(&ui, defTask);
 
   // norm weights
-  if (task_.num_norms) {
+  if (task_.num_cost) {
     mjuiDef defNormWeight[kMaxCostTerms + 1];
-    for (int i = 0; i < task_.num_norms; i++) {
+    for (int i = 0; i < task_.num_cost; i++) {
       // element
       defNormWeight[i] = {mjITEM_SLIDERNUM, "weight", 2,
                           DataAt(task_.weight, i), "0 1"};
@@ -296,7 +299,7 @@ void Agent::Gui(mjUI& ui) {
       mju::sprintf_arr(defNormWeight[i].other, "%f %f", s[2], s[3]);
     }
 
-    defNormWeight[task_.num_norms] = {mjITEM_END};
+    defNormWeight[task_.num_cost] = {mjITEM_END};
     mjui_add(&ui, defNormWeight);
   }
 
@@ -479,16 +482,16 @@ void Agent::PlotInitialize() {
   plots_.cost.linergb[3][0] = 1.0f;
   plots_.cost.linergb[3][1] = 1.0f;
   plots_.cost.linergb[3][2] = 1.0f;
-  for (int i = 0; i < task_.num_norms; i++) {
+  for (int i = 0; i < task_.num_cost; i++) {
     // history
     plots_.cost.linergb[4 + i][0] = CostColors[i][0];
     plots_.cost.linergb[4 + i][1] = CostColors[i][1];
     plots_.cost.linergb[4 + i][2] = CostColors[i][2];
 
     // prediction
-    plots_.cost.linergb[4 + task_.num_norms + i][0] = 0.9 * CostColors[i][0];
-    plots_.cost.linergb[4 + task_.num_norms + i][1] = 0.9 * CostColors[i][1];
-    plots_.cost.linergb[4 + task_.num_norms + i][2] = 0.9 * CostColors[i][2];
+    plots_.cost.linergb[4 + task_.num_cost + i][0] = 0.9 * CostColors[i][0];
+    plots_.cost.linergb[4 + task_.num_cost + i][1] = 0.9 * CostColors[i][1];
+    plots_.cost.linergb[4 + task_.num_cost + i][2] = 0.9 * CostColors[i][2];
   }
 
   // history of control
@@ -560,7 +563,7 @@ void Agent::PlotInitialize() {
 // reset plot data to zeros
 void Agent::PlotReset() {
   // cost reset
-  for (int k = 0; k < 4 + 2 * task_.num_norms; k++) {
+  for (int k = 0; k < 4 + 2 * task_.num_cost; k++) {
     PlotResetData(&plots_.cost, 1000, k);
   }
 
@@ -606,7 +609,7 @@ void Agent::Plots(const mjData* data, int shift) {
 
   // compute individual costs
   for (int t = 0; t < winner->horizon; t++) {
-    task_.CostTerms(DataAt(terms_, t * task_.num_norms),
+    task_.CostTerms(DataAt(terms_, t * task_.num_cost),
                     DataAt(winner->residual, t * task_.num_residual));
   }
 
@@ -631,21 +634,21 @@ void Agent::Plots(const mjData* data, int shift) {
   mju::strcpy_arr(plots_.cost.linename[0], "Total Cost");
 
   // plot costs
-  for (int k = 0; k < task_.num_norms; k++) {
+  for (int k = 0; k < task_.num_cost; k++) {
     // current residual
     if (shift) {
       PlotUpdateData(&plots_.cost, cost_bounds, data->time, terms_[k], 1000,
                      4 + k, 1, 1, time_lower_bound);
     }
     // legend
-    mju::strcpy_arr(plots_.cost.linename[4 + task_.num_norms + k],
+    mju::strcpy_arr(plots_.cost.linename[4 + task_.num_cost + k],
                     model_->names + model_->name_sensoradr[k]);
   }
 
   // predicted residual
   PlotData(&plots_.cost, cost_bounds, winner->times.data(), terms_.data(),
-           task_.num_norms, task_.num_norms, winner->horizon,
-           4 + task_.num_norms, time_lower_bound);
+           task_.num_cost, task_.num_cost, winner->horizon,
+           4 + task_.num_cost, time_lower_bound);
 
   // vertical lines at current time and agent time
   PlotVertical(&plots_.cost, data->time, cost_bounds[0], cost_bounds[1], 10, 1);

--- a/mjpc/planners/cost_derivatives.cc
+++ b/mjpc/planners/cost_derivatives.cc
@@ -115,7 +115,7 @@ void CostDerivatives::Compute(double* r, double* rx, double* ru,
                               const int* dim_norm_residual, int num_cost,
                               const double* weights, const NormType* norms,
                               const double* parameters,
-                              const int* num_num_parameter, double risk,
+                              const int* num_norm_parameter, double risk,
                               int T, ThreadPool& pool) {
   // reset
   this->Reset(dim_state_derivative, dim_action, num_residual, T);
@@ -124,7 +124,7 @@ void CostDerivatives::Compute(double* r, double* rx, double* ru,
     for (int t = 0; t < T; t++) {
       pool.Schedule([&cd = *this, &r, &rx, &ru, num_cost, num_residual,
                      &dim_norm_residual, &weights, &norms, &parameters,
-                     &num_num_parameter, risk, num_sensors,
+                     &num_norm_parameter, risk, num_sensors,
                      dim_state_derivative, dim_action, dim_max, t, T]() {
         // ----- term derivatives ----- //
         int f_shift = 0;
@@ -154,7 +154,7 @@ void CostDerivatives::Compute(double* r, double* rx, double* ru,
               weights[i] / T, parameters + p_shift, norms[i]);
 
           f_shift += dim_norm_residual[i];
-          p_shift += num_num_parameter[i];
+          p_shift += num_norm_parameter[i];
         }
 
         // ----- risk transformation ----- //

--- a/mjpc/planners/cost_derivatives.cc
+++ b/mjpc/planners/cost_derivatives.cc
@@ -112,25 +112,25 @@ double CostDerivatives::DerivativeStep(
 void CostDerivatives::Compute(double* r, double* rx, double* ru,
                               int dim_state_derivative, int dim_action,
                               int dim_max, int num_sensors, int num_residual,
-                              const int* dim_norm_residual, int num_norms,
+                              const int* dim_norm_residual, int num_cost,
                               const double* weights, const NormType* norms,
                               const double* parameters,
-                              const int* num_norm_parameters, double risk,
+                              const int* num_num_parameter, double risk,
                               int T, ThreadPool& pool) {
   // reset
   this->Reset(dim_state_derivative, dim_action, num_residual, T);
   {
     int count_before = pool.GetCount();
     for (int t = 0; t < T; t++) {
-      pool.Schedule([&cd = *this, &r, &rx, &ru, num_norms, num_residual,
+      pool.Schedule([&cd = *this, &r, &rx, &ru, num_cost, num_residual,
                      &dim_norm_residual, &weights, &norms, &parameters,
-                     &num_norm_parameters, risk, num_sensors,
+                     &num_num_parameter, risk, num_sensors,
                      dim_state_derivative, dim_action, dim_max, t, T]() {
         // ----- term derivatives ----- //
         int f_shift = 0;
         int p_shift = 0;
         double c = 0.0;
-        for (int i = 0; i < num_norms; i++) {
+        for (int i = 0; i < num_cost; i++) {
           c += cd.DerivativeStep(
               DataAt(cd.cx, t * dim_state_derivative),
               DataAt(cd.cu, t * dim_action),
@@ -154,7 +154,7 @@ void CostDerivatives::Compute(double* r, double* rx, double* ru,
               weights[i] / T, parameters + p_shift, norms[i]);
 
           f_shift += dim_norm_residual[i];
-          p_shift += num_norm_parameters[i];
+          p_shift += num_num_parameter[i];
         }
 
         // ----- risk transformation ----- //

--- a/mjpc/planners/cost_derivatives.h
+++ b/mjpc/planners/cost_derivatives.h
@@ -52,9 +52,9 @@ class CostDerivatives {
   // compute derivatives at all time steps
   void Compute(double* r, double* rx, double* ru, int dim_state_derivative,
                int dim_action, int dim_max, int num_sensors, int num_residual,
-               const int* dim_norm_residual, int num_norms,
+               const int* dim_norm_residual, int num_cost,
                const double* weights, const NormType* norms,
-               const double* parameters, const int* num_norm_parameters,
+               const double* parameters, const int* num_num_parameter,
                double risk, int T, ThreadPool& pool);
 
   std::vector<double> cr;   // norm gradient wrt residual

--- a/mjpc/planners/cost_derivatives.h
+++ b/mjpc/planners/cost_derivatives.h
@@ -54,7 +54,7 @@ class CostDerivatives {
                int dim_action, int dim_max, int num_sensors, int num_residual,
                const int* dim_norm_residual, int num_cost,
                const double* weights, const NormType* norms,
-               const double* parameters, const int* num_num_parameter,
+               const double* parameters, const int* num_norm_parameter,
                double risk, int T, ThreadPool& pool);
 
   std::vector<double> cr;   // norm gradient wrt residual

--- a/mjpc/planners/ilqg/planner.cc
+++ b/mjpc/planners/ilqg/planner.cc
@@ -187,7 +187,8 @@ void iLQGPlanner::OptimizePolicy(int horizon, ThreadPool& pool) {
     // compute model and sensor Jacobians
     model_derivative.Compute(
         model, data_, candidate_policy[0].trajectory.states.data(),
-        candidate_policy[0].trajectory.actions.data(), dim_state,
+        candidate_policy[0].trajectory.actions.data(),
+        candidate_policy[0].trajectory.times.data(), dim_state,
         dim_state_derivative, dim_action, dim_sensor, horizon,
         settings.fd_tolerance, settings.fd_mode, pool);
 
@@ -208,7 +209,7 @@ void iLQGPlanner::OptimizePolicy(int horizon, ThreadPool& pool) {
         dim_state_derivative, dim_action, dim_max, dim_sensor,
         task->num_residual, task->dim_norm_residual.data(), task->num_cost,
         task->weight.data(), task->norm.data(), task->num_parameter.data(),
-        task->num_num_parameter.data(), task->risk, horizon, pool);
+        task->num_norm_parameter.data(), task->risk, horizon, pool);
 
     // end timer
     cost_derivative_time +=
@@ -490,8 +491,8 @@ void iLQGPlanner::Rollouts(int horizon, ThreadPool& pool) {
 
       // policy
       auto feedback_policy = [&candidate_policy = candidate_policy, model, i](
-                              double* action, const double* state,
-                              int index) {
+                                 double* action, const double* state,
+                                 int index) {
         // dimensions
         int dim_state = model->nq + model->nv + model->na;
         int dim_state_derivative = 2 * model->nv + model->na;

--- a/mjpc/planners/ilqg/planner.cc
+++ b/mjpc/planners/ilqg/planner.cc
@@ -68,7 +68,7 @@ void iLQGPlanner::Allocate() {
   // candidate trajectories
   for (int i = 0; i < kMaxTrajectory; i++) {
     trajectory[i].Initialize(dim_state, dim_action, task->num_residual,
-                             kMaxTrajectoryHorizon);
+                             task->num_trace, kMaxTrajectoryHorizon);
     trajectory[i].Allocate(kMaxTrajectoryHorizon);
   }
 
@@ -206,9 +206,9 @@ void iLQGPlanner::OptimizePolicy(int horizon, ThreadPool& pool) {
         candidate_policy[0].trajectory.residual.data(),
         model_derivative.C.data(), model_derivative.D.data(),
         dim_state_derivative, dim_action, dim_max, dim_sensor,
-        task->num_residual, task->dim_norm_residual.data(), task->num_norms,
-        task->weight.data(), task->norm.data(), task->norm_parameters.data(),
-        task->num_norm_parameters.data(), task->risk, horizon, pool);
+        task->num_residual, task->dim_norm_residual.data(), task->num_cost,
+        task->weight.data(), task->norm.data(), task->num_parameter.data(),
+        task->num_num_parameter.data(), task->risk, horizon, pool);
 
     // end timer
     cost_derivative_time +=

--- a/mjpc/planners/ilqg/policy.cc
+++ b/mjpc/planners/ilqg/policy.cc
@@ -48,6 +48,7 @@ void iLQGPolicy::Allocate(const mjModel* model, const Task& task, int horizon) {
   // interpolation
   // feedback gains ((T - 1) * dim_action * dim_state_derivative)
   feedback_gain_scratch.resize(model->nu * (2 * model->nv + model->na));
+  
   // state interpolation (dim_state_derivative)
   state_interp.resize(model->nq + model->nv + model->na);
 

--- a/mjpc/planners/ilqg/policy.cc
+++ b/mjpc/planners/ilqg/policy.cc
@@ -31,7 +31,7 @@ void iLQGPolicy::Allocate(const mjModel* model, const Task& task, int horizon) {
 
   // reference trajectory
   trajectory.Initialize(model->nq + model->nv + model->na, model->nu,
-                        task.num_residual, kMaxTrajectoryHorizon);
+                        task.num_residual, task.num_trace, kMaxTrajectoryHorizon);
   trajectory.Allocate(kMaxTrajectoryHorizon);
 
   // feedback gains

--- a/mjpc/planners/ilqg/settings.h
+++ b/mjpc/planners/ilqg/settings.h
@@ -28,7 +28,7 @@ struct iLQGSettings {
   int regularization_type = 0;         // 0: control; 1: feedback; 2: value; 3: none
   int max_regularization_iter =
       5;  // maximum number of regularization updates per iteration
-  int action_limits = 0;  // flag
+  int action_limits = 1;  // flag
   int verbose = 0;        // print optimizer info
 };
 

--- a/mjpc/planners/model_derivatives.cc
+++ b/mjpc/planners/model_derivatives.cc
@@ -44,19 +44,20 @@ void ModelDerivatives::Reset(int dim_state_derivative, int dim_action,
 // compute derivatives at all time steps
 void ModelDerivatives::Compute(const mjModel* m,
                                const std::vector<UniqueMjData>& data,
-                               const double* x, const double* u, int dim_state,
-                               int dim_state_derivative, int dim_action,
+                               const double* x, const double* u, const double* h,
+                               int dim_state, int dim_state_derivative, int dim_action,
                                int dim_sensor, int T, double tol, int mode,
                                ThreadPool& pool) {
   {
     int count_before = pool.GetCount();
     for (int t = 0; t < T; t++) {
-      pool.Schedule([&m, &data, &A = A, &B = B, &C = C, &D = D, &x, &u,
+      pool.Schedule([&m, &data, &A = A, &B = B, &C = C, &D = D, &x, &u, &h,
                      dim_state, dim_state_derivative, dim_action, dim_sensor,
                      tol, mode, t, T]() {
         mjData* d = data[ThreadPool::WorkerId()].get();
         // set state
         SetState(m, d, x + t * dim_state);
+        d->time = h[t];
 
         // Jacobians
         if (t == T - 1) {

--- a/mjpc/planners/model_derivatives.h
+++ b/mjpc/planners/model_derivatives.h
@@ -42,7 +42,7 @@ class ModelDerivatives {
 
   // compute derivatives at all time steps
   void Compute(const mjModel* m, const std::vector<UniqueMjData>& data,
-               const double* x, const double* u, int dim_state,
+               const double* x, const double* u, const double* h, int dim_state,
                int dim_state_derivative, int dim_action, int dim_sensor, int T,
                double tol, int mode, ThreadPool& pool);
 

--- a/mjpc/planners/sampling/planner.cc
+++ b/mjpc/planners/sampling/planner.cc
@@ -79,7 +79,7 @@ void SamplingPlanner::Allocate() {
   // trajectory and parameters
   for (int i = 0; i < kMaxTrajectory; i++) {
     trajectories[i].Initialize(num_state, model->nu, task->num_residual,
-                               kMaxTrajectoryHorizon);
+                               task->num_trace, kMaxTrajectoryHorizon);
     trajectories[i].Allocate(kMaxTrajectoryHorizon);
     candidate_policy[i].Allocate(model, *task, kMaxTrajectoryHorizon);
   }
@@ -371,20 +371,22 @@ void SamplingPlanner::Traces(mjvScene* scn) {
     // plot sample
     for (int i = 0; i < best->horizon - 1; i++) {
       if (scn->ngeom >= scn->maxgeom) continue;
-      // initialize geometry
-      mjv_initGeom(&scn->geoms[scn->ngeom], mjGEOM_LINE, zero3, zero3, zero9,
-                   color);
+      for (int j = 0; j < task->num_trace; j++) {
+        // initialize geometry
+        mjv_initGeom(&scn->geoms[scn->ngeom], mjGEOM_LINE, zero3, zero3, zero9,
+                    color);
 
-      // make geometry
-      mjv_makeConnector(
-          &scn->geoms[scn->ngeom], mjGEOM_LINE, width,
-          trajectories[k].trace[3 * i], trajectories[k].trace[3 * i + 1],
-          trajectories[k].trace[3 * i + 2], trajectories[k].trace[3 * (i + 1)],
-          trajectories[k].trace[3 * (i + 1) + 1],
-          trajectories[k].trace[3 * (i + 1) + 2]);
+        // make geometry
+        mjv_makeConnector(
+            &scn->geoms[scn->ngeom], mjGEOM_LINE, width,
+            trajectories[k].trace[3 * task->num_trace * i + 3 * j], trajectories[k].trace[3 * task->num_trace * i + 1 + 3 * j],
+            trajectories[k].trace[3 * task->num_trace * i + 2 + 3 * j], trajectories[k].trace[3 * task->num_trace * (i + 1) + 3 * j],
+            trajectories[k].trace[3 * task->num_trace * (i + 1) + 1 + 3 * j],
+            trajectories[k].trace[3 * task->num_trace * (i + 1) + 2 + 3 * j]);
 
-      // increment number of geometries
-      scn->ngeom += 1;
+        // increment number of geometries
+        scn->ngeom += 1;
+      }
     }
   }
 }

--- a/mjpc/task.cc
+++ b/mjpc/task.cc
@@ -88,8 +88,15 @@ void Task::GetFrom(const mjModel* model) {
                num_norm_parameters[num_norms]);
       parameter_shift += num_norm_parameters[num_norms];
       num_norms += 1;
+
+      // check for max norms
+      if (num_norms > kMaxCostTerms) {
+        mju_error("Number of cost terms exceeds maximum. Either: 1) reduce number of terms 2) increase kMaxCostTerms");
+      }
     }
   }
+
+
 
   // set residual parameters
   this->SetFeatureParameters(model);

--- a/mjpc/task.cc
+++ b/mjpc/task.cc
@@ -55,7 +55,7 @@ void Task::GetFrom(const mjModel* model) {
 
   // allocate memory
   dim_norm_residual.resize(kMaxCostTerms);
-  num_num_parameter.resize(kMaxCostTerms);
+  num_norm_parameter.resize(kMaxCostTerms);
   norm.resize(kMaxCostTerms);
   weight.resize(kMaxCostTerms);
   num_parameter.resize(2 * kMaxCostTerms);
@@ -73,6 +73,9 @@ void Task::GetFrom(const mjModel* model) {
                      5) == 0) {
       num_trace += 1;
     }
+  }
+  if (num_trace > kMaxTraces) {
+    mju_error("Number of traces should be less than 100\n");
   }
 
   // loop over sensors
@@ -93,10 +96,10 @@ void Task::GetFrom(const mjModel* model) {
       }
       norm[num_cost] = (NormType)s[0];
       weight[num_cost] = s[1];
-      num_num_parameter[num_cost] = NormParameterDimension(s[0]);
+      num_norm_parameter[num_cost] = NormParameterDimension(s[0]);
       mju_copy(DataAt(num_parameter, parameter_shift), s + 4,
-               num_num_parameter[num_cost]);
-      parameter_shift += num_num_parameter[num_cost];
+               num_norm_parameter[num_cost]);
+      parameter_shift += num_norm_parameter[num_cost];
       num_cost += 1;
 
       // check for max norms
@@ -125,7 +128,7 @@ void Task::CostTerms(double* terms, const double* residual) const {
     f_shift += dim_norm_residual[k];
 
     // shift parameters
-    p_shift += num_num_parameter[k];
+    p_shift += num_norm_parameter[k];
   }
 }
 

--- a/mjpc/task.h
+++ b/mjpc/task.h
@@ -68,12 +68,13 @@ class Task {
 
   // cost parameters
   int num_residual;
-  int num_norms;
+  int num_cost;
+  int num_trace;
   std::vector<int> dim_norm_residual;
-  std::vector<int> num_norm_parameters;
+  std::vector<int> num_num_parameter;
   std::vector<NormType> norm;
   std::vector<double> weight;
-  std::vector<double> norm_parameters;
+  std::vector<double> num_parameter;
   double risk;
 
   // residual parameters

--- a/mjpc/task.h
+++ b/mjpc/task.h
@@ -26,7 +26,7 @@ namespace mjpc {
 inline constexpr double kRiskNeutralTolerance = 1.0e-6;
 
 // maximum cost terms
-inline constexpr int kMaxCostTerms = 10;
+inline constexpr int kMaxCostTerms = 30;
 
 using ResidualFunction = void(const double* parameters, const mjModel* model,
                               const mjData* data, double* residual);

--- a/mjpc/task.h
+++ b/mjpc/task.h
@@ -71,7 +71,7 @@ class Task {
   int num_cost;
   int num_trace;
   std::vector<int> dim_norm_residual;
-  std::vector<int> num_num_parameter;
+  std::vector<int> num_norm_parameter;
   std::vector<NormType> norm;
   std::vector<double> weight;
   std::vector<double> num_parameter;

--- a/mjpc/tasks/acrobot/task.xml
+++ b/mjpc/tasks/acrobot/task.xml
@@ -20,7 +20,7 @@
     <user name="Distance" dim="2" user="0 50.0 0 100.0"/>
     <user name="Velocity" dim="2" user="0  1.0 0 10.0"/>
     <user name="Control" dim="1" user="0 0.05 0.0 1.0"/>
-    <framepos name="trace" objtype="site" objname="tip"/>
+    <framepos name="trace0" objtype="site" objname="tip"/>
     <framepos name="position" objtype="site" objname="tip"/>
     <framelinvel name="velocity" objtype="site" objname="tip"/>
   </sensor>

--- a/mjpc/tasks/cartpole/task.xml
+++ b/mjpc/tasks/cartpole/task.xml
@@ -21,7 +21,7 @@
     <user name="Centered" dim="1" user="6 10.0 0 100.0 0.01"/>
     <user name="Velocity" dim="1" user="0 0.1 0.0 1.0"/>
     <user name="Control" dim="1" user="0 0.1 0.0 1.0"/>
-    <framepos name="trace" objtype="site" objname="tip"/>
+    <framepos name="trace0" objtype="site" objname="tip"/>
     <framepos name="position" objtype="site" objname="tip"/>
     <framelinvel name="velocity" objtype="site" objname="tip"/>
   </sensor>

--- a/mjpc/tasks/hand/cube.xml
+++ b/mjpc/tasks/hand/cube.xml
@@ -20,7 +20,7 @@
   </worldbody>
 
    <sensor>
-        <framepos name="trace" objtype="body" objname="cube"/>
+        <framepos name="trace0" objtype="body" objname="cube"/>
         <framepos name="cube_position" objtype="body" objname="cube"/>
         <framequat name="cube_orientation" objtype="body" objname="cube"/>
         <framelinvel name="cube_linear_velocity" objtype="body" objname="cube"/>

--- a/mjpc/tasks/humanoid/task_stand.xml
+++ b/mjpc/tasks/humanoid/task_stand.xml
@@ -19,7 +19,7 @@
     <user name="CoM Vel." dim="2" user="0 10.0 0.0 100.0" />
     <user name="Joint Vel." dim="27" user="0 0.01 0.0 0.1" />
     <user name="Control" dim="21" user="3 0.025 0.0 0.1 0.3" />
-    <framepos name="trace" objtype="body" objname="torso"/>
+    <framepos name="trace0" objtype="body" objname="torso"/>
     <framepos name="torso_position" objtype="body" objname="torso"/>
     <framepos name="head_position" objtype="body" objname="head"/>
     <framequat name="head_orientation" objtype="body" objname="head"/>

--- a/mjpc/tasks/humanoid/task_walk.xml
+++ b/mjpc/tasks/humanoid/task_walk.xml
@@ -22,7 +22,7 @@
     <user name="Velocity" dim="2" user="7 0.625 0 25.0 0.2 4.0" />
     <user name="Walk" dim="1" user="7 1.0 0.0 25.0 0.5 3.0" />
     <user name="Control" dim="21" user="3 0.1 0 1.0 0.3" />
-    <framepos name="trace" objtype="body" objname="torso"/>
+    <framepos name="trace0" objtype="body" objname="torso"/>
     <framepos name="torso_position" objtype="body" objname="torso"/>
     <subtreecom name="torso_subcom" body="torso"/>
     <subtreelinvel name="torso_subcomvel" body="torso"/>

--- a/mjpc/tasks/particle/task.xml
+++ b/mjpc/tasks/particle/task.xml
@@ -20,7 +20,7 @@
     <user name="Position" dim="2" user="0 5.0 0.0 10.0" />
     <user name="Velocity" dim="2" user="0 0.1 0.0 1.0" />
     <user name="Control" dim="2" user="0 0.1 0.0 1.0" />
-    <framepos name="trace" objtype="site" objname="tip"/>
+    <framepos name="trace0" objtype="site" objname="tip"/>
     <framepos name="position" objtype="site" objname="tip"/>
     <framelinvel name="velocity" objtype="site" objname="tip"/>
     <framepos name="goal" objtype="body" objname="goal"/>

--- a/mjpc/tasks/quadrotor/task.xml
+++ b/mjpc/tasks/quadrotor/task.xml
@@ -35,7 +35,7 @@
     <user name="Lin. Vel." dim="3" user="0 0.3 0.0 5.0"/>
     <user name="Ang. Vel." dim="3" user="0 0.3 0.0 5.0"/>
     <user name="Control" dim="4" user="0 1.0e-2 0.0 1.0"/>
-    <framepos name="trace" objtype="body" objname="quadrotor"/>
+    <framepos name="trace0" objtype="body" objname="quadrotor"/>
     <framepos name="position" objtype="body" objname="quadrotor"/>
     <framequat name="orientation" objtype="body" objname="quadrotor"/>
     <framelinvel name="linear_velocity" objtype="body" objname="quadrotor"/>

--- a/mjpc/tasks/quadruped/task_flat.xml
+++ b/mjpc/tasks/quadruped/task_flat.xml
@@ -36,7 +36,7 @@
     <user name="Velocity" dim="2" user="7 1 0 5 .2 4" />
     <user name="Heading" dim="2" user="0 1 0 5" />
     <user name="Control" dim="12" user="0 0.2 0.0 1.0" />
-    <framepos      name="trace" objtype="body" objname="trunk"/>
+    <framepos      name="trace0" objtype="body" objname="trunk"/>
     <subtreecom    name="torso_subtreecom" body="trunk"/>
     <subtreelinvel name="torso_subtreelinvel" body="trunk"/>
     <framezaxis    name="torso_up" objtype="xbody" objname="trunk"/>

--- a/mjpc/tasks/quadruped/task_hill.xml
+++ b/mjpc/tasks/quadruped/task_hill.xml
@@ -24,7 +24,7 @@
     <body name="goal" mocap="true" pos="-0.125 -0.625 0.25" quat="0.7071 0 0 -0.7071">
         <geom type="capsule" size="0.1 0.1 0.05" contype="0" conaffinity="0" rgba="0 1 0 .5" fromto="-0.1 0 0 0.1 0 0"/>
     </body>
-    <geom name="floor" size="0 0 0.05" pos="0 0 -0.01" type="plane" rgba="0 0 0 1"/>
+    <geom name="floor" size="50 50 0.05" pos="0 0 -0.01" type="plane" material="blue_grid"/>
   </worldbody>
 
   <include file="a1.xml" />
@@ -35,7 +35,7 @@
     <user name="Body Pos." dim="3" user="0 5.0 0.0 100.0" />
     <user name="Body Rot." dim="9" user="0 1.0 0.0 10.0" />
     <user name="Control" dim="12" user="0 0.25 0.0 1.0" />
-    <framepos      name="trace" objtype="body" objname="trunk"/>
+    <framepos      name="trace0" objtype="body" objname="trunk"/>
     <framepos      name="position" objtype="body" objname="trunk"/>
     <framequat     name="orientation" objtype="xbody" objname="trunk"/>
     <subtreecom    name="torso_subtreecom" body="trunk"/>

--- a/mjpc/tasks/swimmer/task.xml
+++ b/mjpc/tasks/swimmer/task.xml
@@ -25,7 +25,7 @@
   <sensor>
     <user name="Control" dim="5" user="0 0.1 0 0.1" />
     <user name="Distance" dim="2" user="2 30 0 100 0.04" />
-    <framepos name="trace" objtype="geom" objname="nose"/>
+    <framepos name="trace0" objtype="geom" objname="nose"/>
     <framepos name="nose" objtype="geom" objname="nose"/>
     <framepos name="target" objtype="body" objname="target"/>
   </sensor>

--- a/mjpc/tasks/walker/task.xml
+++ b/mjpc/tasks/walker/task.xml
@@ -20,7 +20,7 @@
     <user name="Height" dim="1" user="0 10.0 0.0 10.0" />
     <user name="Rotation" dim="1" user="0 3.0 0.0 5.0" />
     <user name="Speed" dim="1" user="0 1.0 0.0 1.0" />
-    <framepos      name="trace" objtype="site" objname="torso_site"/>
+    <framepos      name="trace0" objtype="site" objname="torso_site"/>
     <framepos      name="torso_position" objtype="xbody" objname="torso"/>
     <subtreecom    name="torso_subtreecom" body="torso"/>
     <subtreelinvel name="torso_subtreelinvel" body="torso"/>

--- a/mjpc/test/agent/cost_derivatives_test.cc
+++ b/mjpc/test/agent/cost_derivatives_test.cc
@@ -64,17 +64,17 @@ TEST(FiniteDifferenceHessianTest, Quadratic) {
 
 //   // set cost
 //   task.num_residual = 1;
-//   task.num_norms = 1;
+//   task.num_cost = 1;
 //   task.dim_norm_residual.resize(1);
 //   task.dim_norm_residual[0] = 3;
-//   task.num_norm_parameters.resize(1);
-//   task.num_norm_parameters[0] = 0;
+//   task.num_num_parameter.resize(1);
+//   task.num_num_parameter[0] = 0;
 //   task.norm.resize(1);
 //   task.norm[0] = NormType::kNull;
 //   task.weight.resize(1);
 //   task.weight[0] = 1.23;
-//   task.norm_parameters.resize(1);
-//   task.norm_parameters[0] = 0.0;
+//   task.num_parameter.resize(1);
+//   task.num_parameter[0] = 0.0;
 //   task.risk = 0.35;
 //   task.num_residual_parameters = 0;
 //   task.residual_parameters.resize(1);

--- a/mjpc/test/agent/cost_derivatives_test.cc
+++ b/mjpc/test/agent/cost_derivatives_test.cc
@@ -67,8 +67,8 @@ TEST(FiniteDifferenceHessianTest, Quadratic) {
 //   task.num_cost = 1;
 //   task.dim_norm_residual.resize(1);
 //   task.dim_norm_residual[0] = 3;
-//   task.num_num_parameter.resize(1);
-//   task.num_num_parameter[0] = 0;
+//   task.num_norm_parameter.resize(1);
+//   task.num_norm_parameter[0] = 0;
 //   task.norm.resize(1);
 //   task.norm[0] = NormType::kNull;
 //   task.weight.resize(1);

--- a/mjpc/test/agent/rollout_test.cc
+++ b/mjpc/test/agent/rollout_test.cc
@@ -70,7 +70,7 @@ TEST(RolloutTest, Particle) {
   Trajectory trajectory;
   int horizon = 100;
   trajectory.Initialize(model->nq + model->nv, model->nu, num_residual,
-                        horizon);
+                        0, horizon);
   trajectory.Allocate(horizon);
 
   // ----- rollout ----- //

--- a/mjpc/test/agent/rollout_test.cc
+++ b/mjpc/test/agent/rollout_test.cc
@@ -70,7 +70,7 @@ TEST(RolloutTest, Particle) {
   Trajectory trajectory;
   int horizon = 100;
   trajectory.Initialize(model->nq + model->nv, model->nu, num_residual,
-                        0, horizon);
+                        1, horizon);
   trajectory.Allocate(horizon);
 
   // ----- rollout ----- //

--- a/mjpc/test/agent/trajectory_test.cc
+++ b/mjpc/test/agent/trajectory_test.cc
@@ -26,7 +26,7 @@ TEST(TrajectoryTest, Reset) {
   Trajectory trajectory;
 
   // allocate
-  trajectory.Initialize(2, 2, 2, 2);
+  trajectory.Initialize(2, 2, 2, 1, 2);
   trajectory.Allocate(2);
 
   // fill
@@ -58,9 +58,9 @@ TEST(TrajectoryTest, Copy) {
   Trajectory trajectory_copy;
 
   // allocate
-  trajectory.Initialize(2, 2, 2, 2);
+  trajectory.Initialize(2, 2, 2, 1, 2);
   trajectory.Allocate(2);
-  trajectory_copy.Initialize(2, 2, 2, 2);
+  trajectory_copy.Initialize(2, 2, 2, 1, 2);
   trajectory_copy.Allocate(2);
 
   // fill

--- a/mjpc/test/ilqg_planner/backward_pass_test.cc
+++ b/mjpc/test/ilqg_planner/backward_pass_test.cc
@@ -59,7 +59,7 @@ TEST(iLQGTest, BackwardPass) {
 
   // policy
   iLQGPolicy p;
-  p.trajectory.Initialize(n, m, 0, T);
+  p.trajectory.Initialize(n, m, 0, 0, T);
   p.trajectory.Allocate(T);
   p.feedback_gain.resize(m * n * T);
   p.action_improvement.resize(m * T);

--- a/mjpc/test/tasks/task_test.cc
+++ b/mjpc/test/tasks/task_test.cc
@@ -47,8 +47,8 @@ TEST(TasksTest, Task) {
   EXPECT_EQ(task.num_cost, 2);
   EXPECT_EQ(task.dim_norm_residual[0], 2);
   EXPECT_EQ(task.dim_norm_residual[1], 2);
-  EXPECT_EQ(task.num_num_parameter[0], 0);
-  EXPECT_EQ(task.num_num_parameter[1], 0);
+  EXPECT_EQ(task.num_norm_parameter[0], 0);
+  EXPECT_EQ(task.num_norm_parameter[1], 0);
   EXPECT_EQ(task.norm[0], NormType::kQuadratic);
   EXPECT_EQ(task.norm[1], NormType::kQuadratic);
   EXPECT_NEAR(task.weight[0], 5.0, 1.0e-5);

--- a/mjpc/test/tasks/task_test.cc
+++ b/mjpc/test/tasks/task_test.cc
@@ -44,11 +44,11 @@ TEST(TasksTest, Task) {
 
   // test cost
   EXPECT_EQ(task.num_residual, 4);
-  EXPECT_EQ(task.num_norms, 2);
+  EXPECT_EQ(task.num_cost, 2);
   EXPECT_EQ(task.dim_norm_residual[0], 2);
   EXPECT_EQ(task.dim_norm_residual[1], 2);
-  EXPECT_EQ(task.num_norm_parameters[0], 0);
-  EXPECT_EQ(task.num_norm_parameters[1], 0);
+  EXPECT_EQ(task.num_num_parameter[0], 0);
+  EXPECT_EQ(task.num_num_parameter[1], 0);
   EXPECT_EQ(task.norm[0], NormType::kQuadratic);
   EXPECT_EQ(task.norm[1], NormType::kQuadratic);
   EXPECT_NEAR(task.weight[0], 5.0, 1.0e-5);

--- a/mjpc/test/testdata/cartpole_task.xml
+++ b/mjpc/test/testdata/cartpole_task.xml
@@ -20,7 +20,7 @@
     <user name="Position" dim="2" user="0 1.0 0 100.0"/>
     <user name="Velocity" dim="2" user="0 1.0e-3 0.0 10.0"/>
     <user name="Control" dim="1" user="0 1.0e-3 0.0 10.0"/>
-    <framepos name="trace" objtype="site" objname="tip"/>
+    <framepos name="trace0" objtype="site" objname="tip"/>
     <framepos name="position" objtype="site" objname="tip"/>
     <framelinvel name="velocity" objtype="site" objname="tip"/>
   </sensor>

--- a/mjpc/test/testdata/particle_task.xml
+++ b/mjpc/test/testdata/particle_task.xml
@@ -26,7 +26,7 @@
   <sensor>
     <user name="Position" dim="2" user="0 5.0 0.0 10.0" />
     <user name="Velocity" dim="2" user="0 0.1 0.0 1.0" />
-    <framepos name="trace" objtype="site" objname="tip"/>
+    <framepos name="trace0" objtype="site" objname="tip"/>
     <framepos name="position" objtype="site" objname="tip"/>
     <framelinvel name="velocity" objtype="site" objname="tip"/>
     <framepos name="goal" objtype="body" objname="goal"/>

--- a/mjpc/test/testdata/particle_task.xml
+++ b/mjpc/test/testdata/particle_task.xml
@@ -29,6 +29,7 @@
     <framepos name="trace" objtype="site" objname="tip"/>
     <framepos name="position" objtype="site" objname="tip"/>
     <framelinvel name="velocity" objtype="site" objname="tip"/>
+    <framepos name="goal" objtype="body" objname="goal"/>
   </sensor>
 
   <keyframe>

--- a/mjpc/trajectory.h
+++ b/mjpc/trajectory.h
@@ -38,7 +38,7 @@ class Trajectory {
   // ----- methods -----//
 
   // initialize trajectory dimensions
-  void Initialize(int dim_state, int dim_action, int dim_residual, int horizon);
+  void Initialize(int dim_state, int dim_action, int dim_residual, int num_trace, int horizon);
 
   // allocate memory
   void Allocate(int T);
@@ -62,9 +62,10 @@ class Trajectory {
 
   // ----- members ----- //
   int horizon;                   // trajectory length
-  int dim_state;                 // state dimensions
-  int dim_action;                // action dimensions
-  int dim_feature;               // residual dimensions
+  int dim_state;                 // states dimension
+  int dim_action;                // actions dimension
+  int dim_feature;               // residuals dimension
+  int dim_trace;                 // traces dimension
   std::vector<double> states;    // (horizon   x nq + nv + na)
   std::vector<double> actions;   // (horizon-1 x num_action)
   std::vector<double> times;     // horizon

--- a/mjpc/utilities.cc
+++ b/mjpc/utilities.cc
@@ -84,7 +84,7 @@ double* SensorByName(const mjModel* m, const mjData* d,
                      const std::string& name) {
   int id = mj_name2id(m, mjOBJ_SENSOR, name.c_str());
   if (id == -1) {
-    // std::cerr << "sensor \"" << name << "\" not found.\n";
+    std::cerr << "sensor \"" << name << "\" not found.\n";
     return nullptr;
   } else {
     return d->sensordata + m->sensor_adr[id];
@@ -93,23 +93,19 @@ double* SensorByName(const mjModel* m, const mjData* d,
 
 // get traces from sensors
 void GetTraces(double* traces, const mjModel* m, const mjData* d, int num_trace) {
+  if (num_trace > kMaxTraces) {
+    mju_error("Number of traces should be less than 100\n");
+  }
   if (num_trace == 0) {
     return;
   }
 
-  // get first trace, either "trace" or "trace0"
-  double* trace = SensorByName(m, d, "trace");
-  if (!trace) {
-    trace = SensorByName(m, d, "trace0");
-  }
-  if (trace) mju_copy(traces, trace, 3);
-
   // allocate string
   char str[7];
-  for (int i = 1; i < num_trace; i++) {
+  for (int i = 0; i < num_trace; i++) {
     // set trace id
     mujoco::util_mjpc::sprintf_arr(str, "trace%i", i);
-    trace = SensorByName(m, d, str);
+    double* trace = SensorByName(m, d, str);
     if (trace) mju_copy(traces + 3 * i, trace, 3);
   }
 }

--- a/mjpc/utilities.cc
+++ b/mjpc/utilities.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "array_safety.h"
 #include "utilities.h"
 
 #include <cerrno>
@@ -83,10 +84,33 @@ double* SensorByName(const mjModel* m, const mjData* d,
                      const std::string& name) {
   int id = mj_name2id(m, mjOBJ_SENSOR, name.c_str());
   if (id == -1) {
-    std::cerr << "sensor \"" << name << "\" not found.\n";
+    // std::cerr << "sensor \"" << name << "\" not found.\n";
     return nullptr;
   } else {
     return d->sensordata + m->sensor_adr[id];
+  }
+}
+
+// get traces from sensors
+void GetTraces(double* traces, const mjModel* m, const mjData* d, int num_trace) {
+  if (num_trace == 0) {
+    return;
+  }
+
+  // get first trace, either "trace" or "trace0"
+  double* trace = SensorByName(m, d, "trace");
+  if (!trace) {
+    trace = SensorByName(m, d, "trace0");
+  }
+  if (trace) mju_copy(traces, trace, 3);
+
+  // allocate string
+  char str[7];
+  for (int i = 1; i < num_trace; i++) {
+    // set trace id
+    mujoco::util_mjpc::sprintf_arr(str, "trace%i", i);
+    trace = SensorByName(m, d, str);
+    if (trace) mju_copy(traces + 3 * i, trace, 3);
   }
 }
 

--- a/mjpc/utilities.h
+++ b/mjpc/utilities.h
@@ -61,6 +61,9 @@ void Clamp(double* x, const double* bounds, int n);
 double* SensorByName(const mjModel* m, const mjData* d,
                      const std::string& name);
 
+// get traces from sensors
+void GetTraces(double* traces, const mjModel* m, const mjData* d, int num_trace);
+
 // get keyframe data using string
 double* KeyFrameByName(const mjModel* m, const mjData* d,
                        const std::string& name);

--- a/mjpc/utilities.h
+++ b/mjpc/utilities.h
@@ -27,6 +27,9 @@
 
 namespace mjpc {
 
+// maximum number of traces that are visualized
+inline constexpr int kMaxTraces = 99;
+
 // set mjData state
 void SetState(const mjModel* model, mjData* data, const double* state);
 


### PR DESCRIPTION
Adds support for visualizing multiple traces. 
- Visualizing a single trace now requires specifying "trace0".
- Additional traces are specified with an index, e.g., "trace1", "trace2", etc.

Minor fixes:
- Turn on iLQG action limits by default (this was accidentally turned off--fortunately, doesn't seem to make a meaningful difference on any examples I tested)
- Increase `kMaxCostTerms = 30` + a warning if this value is exceeded by the xml cost specification.
- Set time in `ModelDerivatives::Compute`
- Set quadruped hill task floor to default