### PR TITLE
Minor fixes

### DIFF
--- a/mjpc/planners/gradient/planner.cc
+++ b/mjpc/planners/gradient/planner.cc
@@ -53,7 +53,7 @@ void GradientPlanner::Initialize(mjModel* model, const Task& task) {
       2 * model->nv + model->na;    // state derivative dimension
   dim_action = model->nu;           // action dimension
   dim_sensor = model->nsensordata;  // number of sensor values
-  dim_max = 10 * mju_max(mju_max(mju_max(dim_state, dim_state_derivative),
+  dim_max = mju_max(mju_max(mju_max(dim_state, dim_state_derivative),
                                  dim_action),
                          model->nuser_sensor);
   num_trajectory = GetNumberOrDefault(32, model, "gradient_num_trajectory");

--- a/mjpc/planners/ilqg/planner.cc
+++ b/mjpc/planners/ilqg/planner.cc
@@ -51,7 +51,7 @@ void iLQGPlanner::Initialize(mjModel* model, const Task& task) {
       2 * model->nv + model->na;    // state derivative dimension
   dim_action = model->nu;           // action dimension
   dim_sensor = model->nsensordata;  // number of sensor values
-  dim_max = 10 * mju_max(mju_max(mju_max(dim_state, dim_state_derivative),
+  dim_max = mju_max(mju_max(mju_max(dim_state, dim_state_derivative),
                                  dim_action),
                          model->nuser_sensor);
   num_trajectory = GetNumberOrDefault(10, model, "ilqg_num_rollouts");

--- a/mjpc/tasks/particle/particle.cc
+++ b/mjpc/tasks/particle/particle.cc
@@ -15,6 +15,7 @@
 #include "tasks/particle/particle.h"
 
 #include <mujoco/mujoco.h>
+#include "task.h"
 #include "utilities.h"
 
 namespace mjpc {
@@ -61,6 +62,20 @@ void Particle::ResidualTimeVarying(const double* parameters,
 
   // ----- residual (2) ----- //
   mju_copy(residual + 4, data->ctrl, model->nu);
+}
+
+int Particle::Transition(int state, const mjModel* model, mjData* data,
+                         Task* task) {
+  int new_state = state;
+
+  // some Lissajous curve
+  double goal[2] {0.25 * mju_sin(data->time), 0.25 * mju_cos(data->time / mjPI)};
+
+  // update mocap position
+  data->mocap_pos[0] = goal[0];
+  data->mocap_pos[1] = goal[1];
+
+  return new_state;
 }
 
 }  // namespace mjpc

--- a/mjpc/tasks/particle/particle.h
+++ b/mjpc/tasks/particle/particle.h
@@ -16,6 +16,7 @@
 #define MJPC_TASKS_PARTICLE_PARTICLE_H_
 
 #include <mujoco/mujoco.h>
+#include "task.h"
 
 namespace mjpc {
 struct Particle {
@@ -30,6 +31,9 @@ static void Residual(const double* parameters, const mjModel* model,
 
 static void ResidualTimeVarying(const double* parameters, const mjModel* model,
                                 const mjData* data, double* residual);
+
+static int Transition(int state, const mjModel* model, mjData* data,
+                                Task* task);
 
 };
 }  // namespace mjpc

--- a/mjpc/tasks/particle/particle.xml
+++ b/mjpc/tasks/particle/particle.xml
@@ -9,6 +9,9 @@
   </default>
 
   <worldbody>
+    <body name="goal" mocap="true" pos="0.25 0 0.01" quat="1 0 0 0">
+        <geom type="sphere" size=".01" contype="0" conaffinity="0" rgba="0 1 0 .5"/>
+    </body>
     <light name="light" pos="0 0 1"/>
     <camera name="fixed" pos="0 0 .75" quat="1 0 0 0"/>
     <geom name="ground" type="plane" pos="0 0 0" size=".3 .3 .1" material="blue_grid"/>

--- a/mjpc/tasks/particle/task_timevarying.xml
+++ b/mjpc/tasks/particle/task_timevarying.xml
@@ -5,6 +5,7 @@
   <size memory="10K"/>
 
   <custom>
+    <numeric name="task_transition" data="1" />
     <numeric name="task_risk" data="1" />
     <numeric name="agent_planner" data="0" />
     <numeric name="agent_horizon" data="0.5" />

--- a/mjpc/tasks/tasks.cc
+++ b/mjpc/tasks/tasks.cc
@@ -69,6 +69,7 @@ const TaskDefinition<const char*> kTasksArray[]{
         .name = "Particle",
         .xml_path = "particle/task_timevarying.xml",
         .residual = &Particle::ResidualTimeVarying,
+        .transition = &Particle::Transition,
     },
     {
         .name = "Quadruped Hill",


### PR DESCRIPTION
- Fix `dim_max` during gradient-based planner initialization. This enables tasks with much larger dimensions.
- Max action plot dimension: `kMaxActionPlots = 25`. Helps prevent plotting issues for tasks with large action spaces. 
- Time-varying goal visualization for particle task.