### PR TITLE
Add custom labeled buttons to transition GUI and set userdata

### DIFF
--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -18,23 +18,23 @@
 
 $$
 \begin{align*}
-    \underset{s_{1:{T}}, a_{1:T}}{\text{minimize }} & \, \sum \limits_{t = 0}^{T} c(s_t, a_t),\\
-    \text{s.t.} & \, s_{t+1} = m(s_t, a_t),\\
-    & (s_0 \, \text{given}),
+    \underset{x_{1:{T}}, u_{1:T}}{\text{minimize }} & \quad \sum \limits_{t = 0}^{T} c(x_t, u_t),\\
+    \text{subject to} & \quad x_{t+1} = f(x_t, u_t),\\
+    & \quad (x_0 \, \text{given}),
 \end{align*}
 $$
 
-where the goal is to optimize state $s \in \mathbf{S}$, action $a \in \mathbf{A}$ trajectories subject to a model $m : \mathbf{S} \times \mathbf{A} \rightarrow \mathbf{S}$ specifying the transition dynamics of the system. The minimization objective is the total return, which is the sum of step-wise values $c : \mathbf{S} \times \mathbf{A} \rightarrow \mathbf{R}_{+}$ along the trajectory from the current time until the horizon $T$.
+where the goal is to optimize state, $x \in \mathbf{R}^n$, action $u \in \mathbf{R}^m$ trajectories subject to a model $f : \mathbf{R}^n \times \mathbf{R}^m \rightarrow \mathbf{R}^n$ specifying the transition dynamics of the system. The minimization objective is the total return, which is the sum of step-wise values $c : \mathbf{R}^n \times \mathbf{R}^m \rightarrow \mathbf{R}_{+}$ along the trajectory from the current time until the horizon $T$.
 
 ## Cost Function
 
-Behaviors are designed by specifying a per-timestep cost $c$ of the form:
+Behaviors are designed by specifying a per-timestep cost $l$ of the form:
 
 $$
-c(s, a) = \sum_i^N w_i \cdot \text{n}_i\Big(\textbf{r}_i(s, a)\Big)
+l(x, u) = \sum_i^M w_i \cdot \text{n}_i\Big(\textbf{r}_i(x, u)\Big)
 $$
 
-The cost is a sum of $N$ terms, each comprising:
+The cost is a sum of $M$ terms, each comprising:
 
 - A nonnegative scalar weight $w \ge 0$ that determines the relative importance of this term.
 - A norm function $\rm n(\cdot)$ taking a vector and returning a non-negative scalar that achieves its minimum at $\bf 0$.
@@ -42,22 +42,22 @@ The cost is a sum of $N$ terms, each comprising:
 
 ### Risk (in)sensitive costs
 
-We additionally provide a convenient family of exponential transformations $J(s, a; R) = f(c(s, a), R)$ that can be applied to the cost function to model risk-seeking and risk-averse behaviors. This family is parameterized by a scalar $R \in \mathbf{R}$ (our default is $R=0$) and is given by:
+We additionally provide a convenient family of exponential transformations, $c(x, u) = \rho(l(x, u); R), that can be applied to the cost function to model risk-seeking and risk-averse behaviors. This family is parameterized by a scalar $R \in \mathbf{R}$ (our default is $R=0$) and is given by:
 
 $$
-f(x, R) = \frac{e^{R \cdot x} - 1}{R}.
+\rho(l, R) = \frac{e^{R \cdot l} - 1}{R}.
 $$
 
-The mapping, $f : \mathbf{R}_ {+} \times \mathbf{R} \rightarrow \mathbf{R}_ {+}$, has the following properties:
+The mapping, $\rho : \mathbf{R}_ {+} \times \mathbf{R} \rightarrow \mathbf{R}_ {+}$, has the following properties:
 
 - It is defined and smooth for any $R$
-- At $R=0$, it reduces to the identity $f(x; 0) = x$
-- 0 is a fixed point of the function: $f(0; R) = 0$
-- It is nonnegative: $f(x; R) \geq 0$ if $x \geq 0$
-- It is strictly monotonic: $f(x; R) \gt f(y; R)$ if $x > y$
-- The value of $f(x;R)$ has the same unit as $x$
+- At $R=0$, it reduces to the identity $\rho(l; 0) = l$
+- 0 is a fixed point of the function: $\rho(0; R) = 0$
+- It is nonnegative: $\rho(l; R) \geq 0$ if $l \geq 0$
+- It is strictly monotonic: $\rho(l; R) \gt \rho(q; R)$ if $l > q$
+- The value of $\rho(l; R)$ has the same unit as $l$
 
-$R=0$ can be interpreted as risk neutral, $R>0$ as risk-averse, and $R<0$ as risk-seeking. See [Whittle et. al, 1981](https://www.jstor.org/stable/1426972) for more details on risk sensitive control. Furthermore, when $R < 0$, this transformation creates cost functions that are equivalent to the rewards commonly used in the Reinforcement Learning literature. For example using the quadratic norm $\text{n}(\textbf{r}) = \textbf{r}^T Q \textbf{r}$ for some symmetric positive definite (SPD) matrix $Q=\Sigma^{-1}$ and a risk parameter $R=-1$ leads to an inverted-Gaussian cost $c=1 - e^{-\textbf{r}^T \Sigma^{-1} \textbf{r}}$, whose minimisation is equivalent to performing maximum likelihood estimation for the Gaussian.
+$R=0$ can be interpreted as risk neutral, $R>0$ as risk-averse, and $R<0$ as risk-seeking. See [Whittle et. al, 1981](https://www.jstor.org/stable/1426972) for more details on risk sensitive control. Furthermore, when $R < 0$, this transformation creates cost functions that are equivalent to the rewards commonly used in the Reinforcement Learning literature. For example using the quadratic norm $\text{n}(\textbf{r}) = \textbf{r}^T Q \textbf{r}$ for some symmetric positive definite (SPD) matrix $Q=\Sigma^{-1}$ and a risk parameter $R=-1$ leads to an inverted-Gaussian cost $1 - e^{-\textbf{r}^T \Sigma^{-1} \textbf{r}}$, whose minimisation is equivalent to performing maximum likelihood estimation for the Gaussian.
 
 ## Cost Derivatives
 
@@ -65,23 +65,23 @@ Many planners (e.g., Gradient Descent and [iLQG](https://homes.cs.washington.edu
 
 Gradients are computed exactly:
 
-$$ \frac{\partial c}{\partial s} = \sum \limits_{i} w_i \cdot \frac{\partial \text{n}_i}{\partial \textbf{r}} \frac{\partial \textbf{r}_i}{\partial s},$$
+$$ \frac{\partial l}{\partial x} = \sum \limits_{i} w_i \cdot \frac{\partial \text{n}_i}{\partial \textbf{r}} \frac{\partial \textbf{r}_i}{\partial x},$$
 
-$$ \frac{\partial c}{\partial a} = \sum \limits_{i} w_i \cdot \frac{\partial \text{n}_i}{\partial \textbf{r}} \frac{\partial \textbf{r}_i}{\partial a}.$$
+$$ \frac{\partial l}{\partial u} = \sum \limits_{i} w_i \cdot \frac{\partial \text{n}_i}{\partial \textbf{r}} \frac{\partial \textbf{r}_i}{\partial u}.$$
 
 Hessians are approximated:
 
-$$ \frac{\partial^2 c}{\partial s^2} \approx \sum \limits_{i} w_i \cdot \Big(\frac{\partial \textbf{r}_i}{\partial s}\Big)^T\frac{\partial^2 \text{n}_i}{\partial \textbf{r}^2} \frac{\partial \textbf{r}_i}{\partial s},$$
+$$ \frac{\partial^2 l}{\partial x^2} \approx \sum \limits_{i} w_i \cdot \Big(\frac{\partial \textbf{r}_i}{\partial x}\Big)^T\frac{\partial^2 \text{n}_i}{\partial \textbf{r}^2} \frac{\partial \textbf{r}_i}{\partial x},$$
 
-$$ \frac{\partial^2 c}{\partial a^2} \approx \sum \limits_{i} w_i \cdot \Big(\frac{\partial \textbf{r}_i}{\partial a}\Big)^T\frac{\partial^2 \text{n}_i}{\partial \textbf{r}^2} \frac{\partial \textbf{r}_i}{\partial a},$$
+$$ \frac{\partial^2 l}{\partial u^2} \approx \sum \limits_{i} w_i \cdot \Big(\frac{\partial \textbf{r}_i}{\partial u}\Big)^T\frac{\partial^2 \text{n}_i}{\partial \textbf{r}^2} \frac{\partial \textbf{r}_i}{\partial u},$$
 
-$$ \frac{\partial^2 c}{\partial s \, \partial a} \approx \sum \limits_{i} w_i \cdot \Big(\frac{\partial \textbf{r}_i}{\partial s}\Big)^T \frac{\partial^2 \text{n}_i}{\partial \textbf{r}^2} \frac{\partial \textbf{r}_i}{\partial a},$$
+$$ \frac{\partial^2 l}{\partial x \, \partial u} \approx \sum \limits_{i} w_i \cdot \Big(\frac{\partial \textbf{r}_i}{\partial x}\Big)^T \frac{\partial^2 \text{n}_i}{\partial \textbf{r}^2} \frac{\partial \textbf{r}_i}{\partial u},$$
 
 via [Gauss-Newton](https://en.wikipedia.org/wiki/Gauss%E2%80%93Newton_algorithm).
 
-Derivatives of $\text{norm}$, i.e., $\frac{\partial \text{norm}}{\partial \text{residual}}$, $\frac{\partial^2 \text{norm}}{\partial \text{residual}^2}$, are computed [analytically](../mjpc/norm.cc).
+Derivatives of $\text{n}$, i.e., $\frac{\partial \text{n}}{\partial \text{r}}$, $\frac{\partial^2 \text{n}}{\partial \text{r}^2}$, are computed [analytically](../mjpc/norm.cc).
 
-The $\text{residual}$ Jacobians, i.e., $\frac{\partial \text{residual}}{\partial \text{state}}$, $\frac{\partial \text{residual}}{\partial \text{action}}$, are computed efficiently using MuJoCo's efficient [finite-difference utility](https://mujoco.readthedocs.io/en/latest/APIreference.html#mjd-transitionfd).
+The residual Jacobians, i.e., $\frac{\partial \text{r}}{\partial x}$, $\frac{\partial \text{r}}{\partial u}$, are computed efficiently using MuJoCo's efficient [finite-difference utility](https://mujoco.readthedocs.io/en/latest/APIreference.html#mjd-transitionfd).
 
 ### Risk (in)sensitive derivatives
 
@@ -89,17 +89,17 @@ Likewise, we also provide derivaties for the risk (in)sensitive cost functions.
 
 Gradients are computed exactly:
 
-$$ \frac{\partial J}{\partial s} = e^{R \cdot c} \cdot \frac{\partial c}{\partial s},$$
+$$ \frac{\partial c}{\partial x} = e^{R \cdot l} \cdot \frac{\partial l}{\partial x},$$
 
-$$ \frac{\partial J}{\partial a} = e^{R \cdot c} \cdot \frac{\partial c}{\partial a}.$$
+$$ \frac{\partial c}{\partial u} = e^{R \cdot l} \cdot \frac{\partial l}{\partial u}.$$
 
 Hessians are approximated:
 
-$$ \frac{\partial^2 J}{\partial s^2} \approx e^{R \cdot c} \cdot \frac{\partial^2 c}{\partial s^2} + R \cdot e^{R \cdot c} \cdot \Big(\frac{\partial c}{\partial s}\Big)^T \frac{\partial c}{\partial s},$$
+$$ \frac{\partial^2 c}{\partial x^2} \approx e^{R \cdot l} \cdot \frac{\partial^2 l}{\partial x^2} + R \cdot e^{R \cdot l} \cdot \Big(\frac{\partial l}{\partial x}\Big)^T \frac{\partial l}{\partial x},$$
 
-$$ \frac{\partial^2 J}{\partial a^2} \approx e^{R \cdot c} \cdot \frac{\partial^2 c}{\partial a^2} + R \cdot e^{R \cdot c} \cdot \Big(\frac{\partial c}{\partial a}\Big)^T \frac{\partial c}{\partial a},$$
+$$ \frac{\partial^2 c}{\partial u^2} \approx e^{R \cdot l} \cdot \frac{\partial^2 l}{\partial u^2} + R \cdot e^{R \cdot l} \cdot \Big(\frac{\partial l}{\partial u}\Big)^T \frac{\partial l}{\partial u},$$
 
-$$ \frac{\partial^2 J}{\partial s \, \partial a} \approx e^{R \cdot c} \cdot \frac{\partial^2 c}{\partial s \partial a} + R \cdot e^{R \cdot c} \cdot \Big(\frac{\partial c}{\partial s}\Big)^T \frac{\partial c}{\partial a},$$
+$$ \frac{\partial^2 c}{\partial x \, \partial u} \approx e^{R \cdot l} \cdot \frac{\partial^2 l}{\partial x \partial u} + R \cdot e^{R \cdot l} \cdot \Big(\frac{\partial l}{\partial x}\Big)^T \frac{\partial l}{\partial u},$$
 
 as before, via Gauss-Newton.
 
@@ -225,12 +225,15 @@ The swimmer's cost has two terms:
 The repository includes additional example tasks:
 
 - Humanoid [Stand](../mjpc/tasks/humanoid/stand/task.xml) | [Walk](../mjpc/tasks/humanoid/walk/task.xml)
-- Quadruped [Terrain](../mjpc/tasks/quadruped/task_hill.xml) | [Flat](../mjpc/tasks/quadruped/task_flat.xml)
+- [Swimmer](../mjpc/tasks/swimmer/task.xml)
 - [Walker](../mjpc/tasks/walker/task.xml)
-- [In-Hand Manipulation](../mjpc/tasks/hand/task.xml)
 - [Cart-Pole](../mjpc/tasks/cartpole/task.xml)
+- [Acrobot](../mjpc/tasks/acrobot/task.xml)
 - [Particle](../mjpc/tasks/particle/task.xml)
+- Quadruped [Hill](../mjpc/tasks/quadruped/task_hill.xml) | [Flat](../mjpc/tasks/quadruped/task_flat.xml)
+- [In-Hand Manipulation](../mjpc/tasks/hand/task.xml)
 - [Quadrotor](../mjpc/tasks/quadrotor/task.xml)
+- [Panda Arm Manipulation](../mjpc/tasks/panda/task.xml)
 
 ### Task Transitions
 
@@ -240,12 +243,14 @@ The `task` [class](../mjpc/task.h) supports *transitions* for subgoal-reaching t
 int Swimmer::Transition(
   int state,
   const mjModel* model,
-  mjData* data)
+  mjData* data,
+  Task* task)
 ```
 
 - `state`: an integer marking the current task mode.  This is useful when the sub-goals are enumerable (e.g., when cycling between keyframes).  If the user uses this feature, the function should return a new state upon transition.
 - `model`: the task's `mjModel`.  It is marked `const` because changes to it here will only affect the GUI and will not affect the planner's copies.
 - `data`: the task's `mjData`.  A transition should mutate fields of `mjData`, see below.
+- `task`: task object.
 
 Because we only sync the `mjData` [state](https://mujoco.readthedocs.io/en/latest/computation.html?highlight=state#the-state) between the GUI and the agent's planner, tasks that need transitions should use `mocap` [fields](https://mujoco.readthedocs.io/en/latest/modeling.html#cmocap) to specify goals.  For code examples, see the `Transition` functions in these example tasks: [Swimmer](../mjpc/tasks/swimmer/swimmer.cc) (relocating the target), [Quadruped](../mjpc/tasks/quadruped/quadruped.cc) (iterating along a fixed set of targets) and [Hand](../mjpc/tasks/hand/hand.cc) (recovering when the cube is dropped).
 
@@ -255,12 +260,29 @@ The purpose of `Planner` is to find improved policies using numerical optimizati
 
 This library includes three planners that use different techniques to perform this search:
 
-- **Zero-Order**
-  - Random Search
+- **Predictive Sampling**
+  - random search
   - derivative free
-- **First-Order**
-  - Gradient Descent
+  - spline representation for controls
+- **Gradient Descent**
   - requires gradients
-- **Second-Order**
-  - Iterative Linear Quadratic Gaussian (iLQG)
+  - spline representation for controls
+- **Iterative Linear Quadratic Gausian (iLQG)**
   - requires gradients and Hessians
+  - direct representation for controls
+
+## State
+
+Rollouts are performed after setting both the simulation and initialization states.
+
+### Simulation State 
+This includes: 
+- configuration: `data->qpos`
+- velocity: `data->qvel`
+- acceleration: `data->qacc`
+
+### Initialization State 
+This includes: 
+- mocap: `data->mocap`
+- userdata: `data->userdata`
+- time: `data->time`

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -241,7 +241,6 @@ The `task` [class](../mjpc/task.h) supports *transitions* for subgoal-reaching t
 
 ```c++
 int Swimmer::Transition(
-  int state,
   const mjModel* model,
   mjData* data,
   Task* task)
@@ -252,7 +251,14 @@ int Swimmer::Transition(
 - `data`: the task's `mjData`.  A transition should mutate fields of `mjData`, see below.
 - `task`: task object.
 
-Because we only sync the `mjData` [state](https://mujoco.readthedocs.io/en/latest/computation.html?highlight=state#the-state) between the GUI and the agent's planner, tasks that need transitions should use `mocap` [fields](https://mujoco.readthedocs.io/en/latest/modeling.html#cmocap) to specify goals.  For code examples, see the `Transition` functions in these example tasks: [Swimmer](../mjpc/tasks/swimmer/swimmer.cc) (relocating the target), [Quadruped](../mjpc/tasks/quadruped/quadruped.cc) (iterating along a fixed set of targets) and [Hand](../mjpc/tasks/hand/hand.cc) (recovering when the cube is dropped).
+Because we only sync the `mjData` [state](https://mujoco.readthedocs.io/en/latest/computation.html?highlight=state#the-state) between the GUI and the agent's planner, tasks that need transitions should use `mocap` [fields](https://mujoco.readthedocs.io/en/latest/modeling.html#cmocap) or `userdata` to specify goals.  For code examples, see the `Transition` functions in these example tasks: [Swimmer](../mjpc/tasks/swimmer/swimmer.cc) (relocating the target), [Quadruped](../mjpc/tasks/quadruped/quadruped.cc) (iterating along a fixed set of targets) and [Hand](../mjpc/tasks/hand/hand.cc) (recovering when the cube is dropped).
+
+Additionally, custom labeled buttons can be added to the GUI by specifying a string of labels delimited with a pipe character: `|`. For example: 
+```xml
+<custom>
+  <text name="task_transition" data="Label (1)|Label (2)|Label(3)" />
+</custom>
+```
 
 ## Planners
 

--- a/mjpc/agent.cc
+++ b/mjpc/agent.cc
@@ -280,7 +280,7 @@ void Agent::ModifyScene(mjvScene* scn) {
 }
 
 // graphical user interface elements for agent and task
-void Agent::Gui(mjUI& ui) {
+void Agent::GUI(mjUI& ui) {
   // ----- task ------ //
   mjuiDef defTask[] = {{mjITEM_SECTION, "Task", 1, nullptr, "AP"},
                        {mjITEM_BUTTON, "Reset", 2, nullptr, " #459"},
@@ -349,19 +349,32 @@ void Agent::Gui(mjUI& ui) {
   mjui_add(&ui, defFeatureParameters);
 
   // transition
-  if (GetCustomNumericData(model_, "task_transition")) {
+  char* names = GetCustomTextData(model_, "task_transition");
+  
+  if (names) {
     mjuiDef defTransition[] = {
         {mjITEM_SEPARATOR, "Transition", 1},
-        {mjITEM_RADIO, "Status", 2, &task_.transition_status, "Off\nOn"},
-        {mjITEM_SLIDERINT, "State", 2, &task_.transition_state, "0 1"},
+        {mjITEM_RADIO, "", 1, &task_.transition_stage, ""},
         {mjITEM_END},
     };
 
-    // set task state limits
-    mju::sprintf_arr(defTransition[2].other, "%i %i", 0, model_->nkey);
+    // concatenate names
+    int len = strlen(names);
+    std::string str;
+    for (int i = 0; i < len; i++) {
+      if (names[i] == '|') {
+        str.push_back('\n');
+      } else {
+        str.push_back(names[i]);
+      }
+    }
+
+    // update buttons
+    mju::strcpy_arr(defTransition[1].other, str.c_str());
 
     // set tolerance limits
-    mju::sprintf_arr(defTransition[3].other, "%f %f", 0.0, 1.0);
+    mju::sprintf_arr(defTransition[2].other, "%f %f", 0.0, 1.0);
+
     mjui_add(&ui, defTransition);
   }
 

--- a/mjpc/agent.h
+++ b/mjpc/agent.h
@@ -71,7 +71,7 @@ class Agent {
   void ModifyScene(mjvScene* scn);
 
   // graphical user interface elements for agent and task
-  void Gui(mjUI& ui);
+  void GUI(mjUI& ui);
 
   // task-based GUI event
   void TaskEvent(mjuiItem* it, mjData* data, std::atomic<int>& uiloadrequest,

--- a/mjpc/app.cc
+++ b/mjpc/app.cc
@@ -206,6 +206,7 @@ void PhysicsLoop(mj::Simulate& sim) {
         for (const auto& task : sim.tasks) {
           concatenated_task_names << task.name << '\n';
         }
+
         const auto& task = sim.tasks[sim.agent.task().id];
         sim.agent.Initialize(m, concatenated_task_names.str(),
                              mjpc::kPlannerNames, task.residual,
@@ -271,9 +272,7 @@ void PhysicsLoop(mj::Simulate& sim) {
       const std::lock_guard<std::mutex> lock(sim.mtx);
 
       if (m) {  // run only if model is present
-        if (sim.agent.task().transition_status == 1) {
-          sim.agent.task().Transition(m, d);
-        }
+        sim.agent.task().Transition(m, d);
 
         // running
         if (sim.run) {

--- a/mjpc/planners/gradient/planner.cc
+++ b/mjpc/planners/gradient/planner.cc
@@ -64,6 +64,7 @@ void GradientPlanner::Allocate() {
   // state
   state.resize(model->nq + model->nv + model->na);
   mocap.resize(7 * model->nmocap);
+  userdata.resize(model->nuserdata);
 
   // candidate trajectories
   for (int i = 0; i < kMaxTrajectory; i++) {
@@ -104,6 +105,7 @@ void GradientPlanner::Reset(int horizon) {
   // state
   std::fill(state.begin(), state.end(), 0.0);
   std::fill(mocap.begin(), mocap.end(), 0.0);
+  std::fill(userdata.begin(), userdata.end(), 0.0);
   time = 0.0;
 
   // model derivatives
@@ -140,7 +142,8 @@ void GradientPlanner::Reset(int horizon) {
 
 // set state
 void GradientPlanner::SetState(State& state) {
-  state.CopyTo(this->state.data(), this->mocap.data(), &this->time);
+  state.CopyTo(this->state.data(), this->mocap.data(), 
+               this->userdata.data(), &this->time);
 }
 
 // optimize nominal policy via gradient descent
@@ -345,7 +348,7 @@ void GradientPlanner::NominalTrajectory(int horizon) {
 
   // nominal policy rollout
   trajectory[0].Rollout(nominal_policy, task, model, data_[0].get(),
-                        state.data(), time, mocap.data(), horizon);
+                        state.data(), time, mocap.data(), userdata.data(), horizon);
 }
 
 // compute action from policy
@@ -395,7 +398,7 @@ void GradientPlanner::Rollouts(int horizon, ThreadPool& pool) {
                    &candidate_policy = candidate_policy,
                    &improvement_step = improvement_step, &model = this->model,
                    &task = this->task, &state = this->state, &time = this->time,
-                   &mocap = this->mocap, horizon, i]() {
+                   &mocap = this->mocap, horizon, &userdata = this->userdata, i]() {
       // scale improvement
       mju_addScl(candidate_policy[i].parameters.data(),
                  candidate_policy[i].parameters.data(),
@@ -413,7 +416,7 @@ void GradientPlanner::Rollouts(int horizon, ThreadPool& pool) {
       // policy rollout
       trajectory[i].Rollout(feedback_policy, task, model,
                             data[ThreadPool::WorkerId()].get(), state.data(),
-                            time, mocap.data(), horizon);
+                            time, mocap.data(), userdata.data(), horizon);
     });
   }
   pool.WaitCount(count_before + num_trajectory);

--- a/mjpc/planners/gradient/planner.h
+++ b/mjpc/planners/gradient/planner.h
@@ -94,6 +94,7 @@ class GradientPlanner : public Planner {
   std::vector<double> state;
   double time;
   std::vector<double> mocap;
+  std::vector<double> userdata;
 
   // policy
   GradientPolicy policy;

--- a/mjpc/planners/ilqg/planner.h
+++ b/mjpc/planners/ilqg/planner.h
@@ -80,6 +80,7 @@ class iLQGPlanner : public Planner {
   std::vector<double> state;
   double time;
   std::vector<double> mocap;
+  std::vector<double> userdata;
 
   // policy
   iLQGPolicy policy;

--- a/mjpc/planners/sampling/planner.h
+++ b/mjpc/planners/sampling/planner.h
@@ -97,6 +97,7 @@ class SamplingPlanner : public Planner {
   std::vector<double> state;
   double time;
   std::vector<double> mocap;
+  std::vector<double> userdata;
 
   // policy
   SamplingPolicy policy; // (Guarded by mtx_)

--- a/mjpc/simulate.cc
+++ b/mjpc/simulate.cc
@@ -900,7 +900,7 @@ void makesections(mj::Simulate* sim) {
   sim->ui1.nsect = 0;
 
   // make
-  sim->agent.Gui(sim->ui0);
+  sim->agent.GUI(sim->ui0);
   makephysics(sim, oldstate0[SECT_PHYSICS]);
   makerendering(sim, oldstate0[SECT_RENDERING]);
   makegroup(sim, oldstate0[SECT_GROUP]);

--- a/mjpc/states/state.cc
+++ b/mjpc/states/state.cc
@@ -28,6 +28,7 @@ void State::Allocate(const mjModel* model) {
   const std::unique_lock<std::shared_mutex> lock(mtx_);
   state_.resize(model->nq + model->nv + model->na);
   mocap_.resize(7 * model->nmocap);
+  userdata_.resize(model->nuserdata);
 }
 
 // reset memory to zeros
@@ -35,6 +36,7 @@ void State::Reset() {
   const std::unique_lock<std::shared_mutex> lock(mtx_);
   std::fill(state_.begin(), state_.end(), (double)0.0);
   std::fill(mocap_.begin(), mocap_.end(), 0.0);
+  std::fill(userdata_.begin(), userdata_.end(), 0.0);
   time_ = 0.0;
 }
 
@@ -45,6 +47,7 @@ void State::Set(const mjModel* model, const mjData* data) {
 
     state_.resize(model->nq + model->nv + model->na);
     mocap_.resize(7 * model->nmocap);
+
     // state
     mju_copy(state_.data(), data->qpos, model->nq);
     mju_copy(DataAt(state_, model->nq), data->qvel, model->nv);
@@ -55,17 +58,22 @@ void State::Set(const mjModel* model, const mjData* data) {
       mju_copy(DataAt(mocap_, 7 * i), data->mocap_pos + 3 * i, 3);
       mju_copy(DataAt(mocap_, 7 * i + 3), data->mocap_quat + 4 * i, 4);
     }
+
+    // userdata 
+    mju_copy(userdata_.data(), data->userdata, model->nuserdata);
+
     // time
     time_ = data->time;
   }
 }
 
 void State::CopyTo(double* dst_state, double* dst_mocap,
-                   double* dst_time) const {
+                   double* dst_userdata, double* dst_time) const {
   const std::shared_lock<std::shared_mutex> lock(mtx_);
   mju_copy(dst_state, this->state_.data(), this->state_.size());
   *dst_time = this->time_;
   mju_copy(dst_mocap, this->mocap_.data(), this->mocap_.size());
+  mju_copy(dst_userdata, this->userdata_.data(), this->userdata_.size());
 }
 
 }  // namespace mjpc

--- a/mjpc/states/state.h
+++ b/mjpc/states/state.h
@@ -48,15 +48,17 @@ class State {
   void Set(const mjModel* model, const mjData* data);
 
   // copy into destination
-  void CopyTo(double* dst_state, double* dst_mocap, double* time) const;
+  void CopyTo(double* dst_state, double* dst_mocap, double* dst_userdata, double* time) const;
 
   const std::vector<double>& state() const { return state_; }
   const std::vector<double>& mocap() const { return mocap_; }
+  const std::vector<double>& userdata() const { return userdata_; }
   double time() const { return time_; }
 
  private:
   std::vector<double> state_;  // (state dimension x 1)
   std::vector<double> mocap_;  // (mocap dimension x 1)
+  std::vector<double> userdata_; // (nuserdata x 1)
   double time_;
   mutable std::shared_mutex mtx_;
 };

--- a/mjpc/task.cc
+++ b/mjpc/task.cc
@@ -159,7 +159,7 @@ void Task::Residuals(const mjModel* m, const mjData* d,
 }
 
 void Task::Transition(const mjModel* m, mjData* d) {
-  transition_(transition_stage, m, d, this);
+  transition_(m, d, this);
 }
 
 // initial residual parameters from model
@@ -191,8 +191,6 @@ void Task::SetFeatureParameters(const mjModel* model) {
   }
 }
 
-int NullTransition(int state, const mjModel* model, mjData* data, Task* task) {
-  return state;
-}
+void NullTransition(const mjModel* model, mjData* data, Task* task) {}
 
 }  // namespace mjpc

--- a/mjpc/task.cc
+++ b/mjpc/task.cc
@@ -38,8 +38,7 @@ void Task::GetFrom(const mjModel* model) {
   // ----- defaults ----- //
 
   // transition
-  transition_status = GetNumberOrDefault(0, model, "task_transition");
-  transition_state = 0;
+  transition_stage = 0;
 
   // risk value
   risk = GetNumberOrDefault(0.0, model, "task_risk");
@@ -160,7 +159,7 @@ void Task::Residuals(const mjModel* m, const mjData* d,
 }
 
 void Task::Transition(const mjModel* m, mjData* d) {
-  transition_state = transition_(transition_state, m, d, this);
+  transition_(transition_stage, m, d, this);
 }
 
 // initial residual parameters from model

--- a/mjpc/task.h
+++ b/mjpc/task.h
@@ -67,8 +67,7 @@ class Task {
   void Transition(const mjModel* m, mjData* d);
 
   int id = 0;             // task ID
-  int transition_state;   // state
-  int transition_status;  // status
+  int transition_stage;   // stage
 
   // cost parameters
   int num_residual;

--- a/mjpc/task.h
+++ b/mjpc/task.h
@@ -33,7 +33,7 @@ class Task;
 
 using ResidualFunction = void(const double* parameters, const mjModel* model,
                               const mjData* data, double* residual);
-using TransitionFunction = int(int state, const mjModel* model, mjData* data,
+using TransitionFunction = void(const mjModel* model, mjData* data,
                                Task* task);
 
 // contains information for computing costs
@@ -94,8 +94,7 @@ class Task {
   TransitionFunction* transition_;
 };
 
-extern int NullTransition(int state, const mjModel* model, mjData* data,
-                          Task* task);
+extern void NullTransition(const mjModel* model, mjData* data, Task* task);
 
 template <typename T = std::string>
 struct TaskDefinition {

--- a/mjpc/tasks/hand/hand.cc
+++ b/mjpc/tasks/hand/hand.cc
@@ -79,8 +79,7 @@ void Hand::Residual(const double* parameters, const mjModel* model,
 //   If cube is within tolerance or floor ->
 //   reset cube into hand.
 // -----------------------------------------------
-int Hand::Transition(int state, const mjModel* model, mjData* data,
-                     Task* task) {
+void Hand::Transition(const mjModel* model, mjData* data, Task* task) {
   // find cube and floor
   int cube = mj_name2id(model, mjOBJ_GEOM, "cube");
   int floor = mj_name2id(model, mjOBJ_GEOM, "floor");
@@ -108,8 +107,6 @@ int Hand::Transition(int state, const mjModel* model, mjData* data,
     }
     mj_forward(model, data);
   }
-
-  return state;
 }
 
 }  // namespace mjpc

--- a/mjpc/tasks/hand/hand.h
+++ b/mjpc/tasks/hand/hand.h
@@ -35,8 +35,7 @@ struct Hand {
 //   If cube is within tolerance or floor ->
 //   reset cube into hand.
 // -----------------------------------------------
-  static int Transition(int state, const mjModel* model, mjData* data,
-                        Task* task);
+static void Transition(const mjModel* model, mjData* data, Task* task);
 };
 }  // namespace mjpc
 

--- a/mjpc/tasks/hand/task.xml
+++ b/mjpc/tasks/hand/task.xml
@@ -4,7 +4,6 @@
   <size memory="1M"/>
 
   <custom>
-    <numeric name="task_transition" data="1" />
     <numeric name="agent_planner" data="0" />
     <numeric name="agent_horizon" data="0.25" />
     <numeric name="agent_timestep" data="0.01" />

--- a/mjpc/tasks/panda/panda.cc
+++ b/mjpc/tasks/panda/panda.cc
@@ -65,14 +65,12 @@ void Panda::Residual(const double* parameters, const mjModel* model,
   }
 }
 
-int Panda::Transition(int stage, const mjModel* model, mjData* data,
-                          Task* task) {
+void Panda::Transition(const mjModel* model, mjData* data, Task* task) {
   double residuals[100];
   double terms[10];
   task->Residuals(model, data, residuals);
   task->CostTerms(terms, residuals);
   double bring_dist = (mju_norm3(residuals+3) + mju_norm3(residuals+6)) / 2;
-
 
   // reset:
   if (data->time > 0 && bring_dist < .015) {
@@ -81,7 +79,6 @@ int Panda::Transition(int stage, const mjModel* model, mjData* data,
     data->qpos[0] = absl::Uniform<double>(gen_, -.5, .5);
     data->qpos[1] = absl::Uniform<double>(gen_, -.5, .5);
     data->qpos[2] = .05;
-
 
     // target:
     data->mocap_pos[0] = absl::Uniform<double>(gen_, -.5, .5);
@@ -92,9 +89,6 @@ int Panda::Transition(int stage, const mjModel* model, mjData* data,
     data->mocap_quat[2] = absl::Uniform<double>(gen_, -1, 1);
     data->mocap_quat[3] = absl::Uniform<double>(gen_, -1, 1);
     mju_normalize4(data->mocap_quat);
-    return 0;
   }
-
-  return stage;
 }
 }  // namespace mjpc

--- a/mjpc/tasks/panda/panda.h
+++ b/mjpc/tasks/panda/panda.h
@@ -21,9 +21,8 @@
 namespace mjpc {
 struct Panda {
   static void Residual(const double* parameters, const mjModel* model,
-                           const mjData* data, double* residual);
-  static int Transition(int stage, const mjModel* model, mjData* data,
-                            Task* task);
+                       const mjData* data, double* residual);
+  static void Transition(const mjModel* model, mjData* data, Task* task);
 };
 }  // namespace mjpc
 

--- a/mjpc/tasks/panda/task.xml
+++ b/mjpc/tasks/panda/task.xml
@@ -4,7 +4,6 @@
   <size memory="1M"/>
 
   <custom>
-    <text name="task_transition" data="1" />
     <numeric name="agent_planner" data="0" />
     <numeric name="agent_horizon" data="0.5" />
     <numeric name="agent_timestep" data="0.009" />

--- a/mjpc/tasks/panda/task.xml
+++ b/mjpc/tasks/panda/task.xml
@@ -4,7 +4,7 @@
   <size memory="1M"/>
 
   <custom>
-    <numeric name="task_transition" data="1" />
+    <text name="task_transition" data="1" />
     <numeric name="agent_planner" data="0" />
     <numeric name="agent_horizon" data="0.5" />
     <numeric name="agent_timestep" data="0.009" />

--- a/mjpc/tasks/particle/particle.cc
+++ b/mjpc/tasks/particle/particle.cc
@@ -64,18 +64,13 @@ void Particle::ResidualTimeVarying(const double* parameters,
   mju_copy(residual + 4, data->ctrl, model->nu);
 }
 
-int Particle::Transition(int state, const mjModel* model, mjData* data,
-                         Task* task) {
-  int new_state = state;
-
+void Particle::Transition(const mjModel* model, mjData* data, Task* task) {
   // some Lissajous curve
   double goal[2] {0.25 * mju_sin(data->time), 0.25 * mju_cos(data->time / mjPI)};
 
   // update mocap position
   data->mocap_pos[0] = goal[0];
   data->mocap_pos[1] = goal[1];
-
-  return new_state;
 }
 
 }  // namespace mjpc

--- a/mjpc/tasks/particle/particle.h
+++ b/mjpc/tasks/particle/particle.h
@@ -32,8 +32,7 @@ static void Residual(const double* parameters, const mjModel* model,
 static void ResidualTimeVarying(const double* parameters, const mjModel* model,
                                 const mjData* data, double* residual);
 
-static int Transition(int state, const mjModel* model, mjData* data,
-                                Task* task);
+static void Transition(const mjModel* model, mjData* data, Task* task);
 
 };
 }  // namespace mjpc

--- a/mjpc/tasks/particle/task_timevarying.xml
+++ b/mjpc/tasks/particle/task_timevarying.xml
@@ -5,7 +5,6 @@
   <size memory="10K"/>
 
   <custom>
-    <numeric name="task_transition" data="1" />
     <numeric name="task_risk" data="1" />
     <numeric name="agent_planner" data="0" />
     <numeric name="agent_horizon" data="0.5" />

--- a/mjpc/tasks/quadrotor/quadrotor.cc
+++ b/mjpc/tasks/quadrotor/quadrotor.cc
@@ -59,45 +59,45 @@ void Quadrotor::Residual(const double* parameters, const mjModel* model,
 }
 
 // ----- Transition for quadrotor task -----
-int Quadrotor::Transition(int state, const mjModel* model, mjData* data,
-                          Task* task) {
-  int new_state = state;
+void Quadrotor::Transition(const mjModel* model, mjData* data, Task* task) {
+  // set stage to GUI selection
+  if (task->transition_stage > 0) {
+    data->userdata[0] = task->transition_stage - 1;
+  } else {
+    // goal position
+    const double* goal_position = data->mocap_pos;
 
-  // goal position
-  const double* goal_position = data->mocap_pos;
+    // goal orientation
+    const double* goal_orientation = data->mocap_quat;
 
-  // goal orientation
-  const double* goal_orientation = data->mocap_quat;
+    // system's position
+    double* position = mjpc::SensorByName(model, data, "position");
 
-  // system's position
-  double* position = mjpc::SensorByName(model, data, "position");
+    // system's orientation
+    double* orientation = mjpc::SensorByName(model, data, "orientation");
 
-  // system's orientation
-  double* orientation = mjpc::SensorByName(model, data, "orientation");
+    // position error
+    double position_error[3];
+    mju_sub3(position_error, position, goal_position);
+    double position_error_norm = mju_norm3(position_error);
 
-  // position error
-  double position_error[3];
-  mju_sub3(position_error, position, goal_position);
-  double position_error_norm = mju_norm3(position_error);
+    // orientation error
+    double geodesic_distance =
+        1.0 - mju_abs(mju_dot(goal_orientation, orientation, 4));
 
-  // orientation error
-  double geodesic_distance =
-      1.0 - mju_abs(mju_dot(goal_orientation, orientation, 4));
-
-  double tolerance = 5.0e-1;
-  if (position_error_norm <= tolerance && geodesic_distance <= tolerance) {
-    // update task state
-    new_state += 1;
-    if (new_state == model->nkey) {
-      new_state = 0;
+    double tolerance = 5.0e-1;
+    if (position_error_norm <= tolerance && geodesic_distance <= tolerance) {
+      // update task state
+      data->userdata[0] += 1;
+      if (data->userdata[0] == model->nkey) {
+        data->userdata[0] = 0;
+      }
     }
   }
 
   // set goal
-  mju_copy3(data->mocap_pos, model->key_mpos + 3 * new_state);
-  mju_copy4(data->mocap_quat, model->key_mquat + 4 * new_state);
-
-  return new_state;
+  mju_copy3(data->mocap_pos, model->key_mpos + 3 * (int)data->userdata[0]);
+  mju_copy4(data->mocap_quat, model->key_mquat + 4 * (int)data->userdata[0]);
 }
 
 }  // namespace mjpc

--- a/mjpc/tasks/quadrotor/quadrotor.h
+++ b/mjpc/tasks/quadrotor/quadrotor.h
@@ -33,8 +33,7 @@ static void Residual(const double* parameters, const mjModel* model,
                      const mjData* data, double* residuals);
 
 // ----- Transition for quadrotor task -----
-static int Transition(int state, const mjModel* model, mjData* data,
-                      Task* task);
+static void Transition(const mjModel* model, mjData* data, Task* task);
 };
 }  // namespace mjpc
 

--- a/mjpc/tasks/quadrotor/task.xml
+++ b/mjpc/tasks/quadrotor/task.xml
@@ -2,25 +2,25 @@
   <include file="../common.xml"/>
   <include file="quadrotor.xml" />
 
-  <size memory="100K"/>
+  <size memory="100K" nuserdata="1"/>
 
   <statistic extent="2" center="0.0 0.0 0.0"/>
 
   <custom>
-    <text name="task_transition" data="1" />
+    <text name="task_transition" data="Loop|Stage1|Stage2|Stage3|Stage4|Stage5|Stage6|Stage7|Stage8|Stage9|Stage10|Stage11|Stage12" />
     <numeric name="agent_planner" data="0" />
     <numeric name="agent_horizon" data="0.5" />
     <numeric name="agent_timestep" data="0.01" />
     <numeric name="sampling_sample_width" data="0.01" />
     <numeric name="sampling_control_width" data="0.015" />
-    <numeric name="sampling_spline_points" data="32" />
+    <numeric name="sampling_spline_points" data="5" />
     <numeric name="sampling_exploration" data="0.3" />
     <numeric name="sampling_processed_noise" data="1" />
     <numeric name="sampling_processed_noise_neighbors" data="3" />
     <numeric name="sampling_processed_noise_passes" data="3" />
     <numeric name="sampling_representation" data="2" />
     <numeric name="sampling_trajectories" data="32" />
-    <numeric name="gradient_spline_points" data="10" />
+    <numeric name="gradient_spline_points" data="5" />
     <numeric name="residual_Lin. Vel. X" data="0 -1.0 1.0" />
     <numeric name="residual_Lin. Vel. Y" data="0 -1.0 1.0" />
     <numeric name="residual_Lin. Vel. Z" data="0 -1.0 1.0" />

--- a/mjpc/tasks/quadrotor/task.xml
+++ b/mjpc/tasks/quadrotor/task.xml
@@ -7,7 +7,7 @@
   <statistic extent="2" center="0.0 0.0 0.0"/>
 
   <custom>
-    <numeric name="task_transition" data="1" />
+    <text name="task_transition" data="1" />
     <numeric name="agent_planner" data="0" />
     <numeric name="agent_horizon" data="0.5" />
     <numeric name="agent_timestep" data="0.01" />

--- a/mjpc/tasks/quadruped/quadruped.cc
+++ b/mjpc/tasks/quadruped/quadruped.cc
@@ -78,8 +78,7 @@ void Quadruped::Residual(const double* parameters, const mjModel* model,
 //   If quadruped is within tolerance of goal ->
 //   set goal to next from keyframes.
 // -----------------------------------------------
-int Quadruped::Transition(int state, const mjModel* model, mjData* data,
-                          Task* task) {
+void Quadruped::Transition(const mjModel* model, mjData* data, Task* task) {
   // set stage to GUI selection
   if (task->transition_stage > 0) {
     data->userdata[0] = task->transition_stage - 1;
@@ -120,8 +119,6 @@ int Quadruped::Transition(int state, const mjModel* model, mjData* data,
   // ---------- Set goal ----------
   mju_copy3(data->mocap_pos, model->key_mpos + 3 * (int)data->userdata[0]);
   mju_copy4(data->mocap_quat, model->key_mquat + 4 * (int)data->userdata[0]);
-
-  return 0;
 }
 
 void Quadruped::ResidualFloor(const double* parameters, const mjModel* model,

--- a/mjpc/tasks/quadruped/quadruped.cc
+++ b/mjpc/tasks/quadruped/quadruped.cc
@@ -80,45 +80,48 @@ void Quadruped::Residual(const double* parameters, const mjModel* model,
 // -----------------------------------------------
 int Quadruped::Transition(int state, const mjModel* model, mjData* data,
                           Task* task) {
-  int new_state = state;
+  // set stage to GUI selection
+  if (task->transition_stage > 0) {
+    data->userdata[0] = task->transition_stage - 1;
+  } else {
+    // ---------- Compute tolerance ----------
+    // goal position
+    const double* goal_position = data->mocap_pos;
 
-  // ---------- Compute tolerance ----------
-  // goal position
-  const double* goal_position = data->mocap_pos;
+    // goal orientation
+    const double* goal_orientation = data->mocap_quat;
 
-  // goal orientation
-  const double* goal_orientation = data->mocap_quat;
+    // system's position
+    double* position = mjpc::SensorByName(model, data, "position");
 
-  // system's position
-  double* position = mjpc::SensorByName(model, data, "position");
+    // system's orientation
+    double* orientation = mjpc::SensorByName(model, data, "orientation");
 
-  // system's orientation
-  double* orientation = mjpc::SensorByName(model, data, "orientation");
+    // position error
+    double position_error[3];
+    mju_sub3(position_error, position, goal_position);
+    double position_error_norm = mju_norm3(position_error);
 
-  // position error
-  double position_error[3];
-  mju_sub3(position_error, position, goal_position);
-  double position_error_norm = mju_norm3(position_error);
+    // orientation error
+    double geodesic_distance =
+        1.0 - mju_abs(mju_dot(goal_orientation, orientation, 4));
 
-  // orientation error
-  double geodesic_distance =
-      1.0 - mju_abs(mju_dot(goal_orientation, orientation, 4));
-
-  // ---------- Check tolerance ----------
-  double tolerance = 1.5e-1;
-  if (position_error_norm <= tolerance && geodesic_distance <= tolerance) {
-    // update task state
-    new_state += 1;
-    if (new_state == model->nkey) {
-      new_state = 0;
+    // ---------- Check tolerance ----------
+    double tolerance = 1.5e-1;
+    if (position_error_norm <= tolerance && geodesic_distance <= tolerance) {
+      // update task state
+      data->userdata[0] += 1;
+      if (data->userdata[0] == model->nkey) {
+        data->userdata[0] = 0;
+      }
     }
   }
 
   // ---------- Set goal ----------
-  mju_copy3(data->mocap_pos, model->key_mpos + 3 * new_state);
-  mju_copy4(data->mocap_quat, model->key_mquat + 4 * new_state);
+  mju_copy3(data->mocap_pos, model->key_mpos + 3 * (int)data->userdata[0]);
+  mju_copy4(data->mocap_quat, model->key_mquat + 4 * (int)data->userdata[0]);
 
-  return new_state;
+  return 0;
 }
 
 void Quadruped::ResidualFloor(const double* parameters, const mjModel* model,

--- a/mjpc/tasks/quadruped/quadruped.h
+++ b/mjpc/tasks/quadruped/quadruped.h
@@ -39,8 +39,7 @@ static void ResidualFloor(const double* parameters, const mjModel* model,
 //   If quadruped is within tolerance of goal ->
 //   set goal to next from keyframes.
 // -----------------------------------------------
-static int Transition(int state, const mjModel* model, mjData* data,
-                      Task* task);
+static void Transition(const mjModel* model, mjData* data, Task* task);
 };
 }  // namespace mjpc
 

--- a/mjpc/tasks/quadruped/task_flat.xml
+++ b/mjpc/tasks/quadruped/task_flat.xml
@@ -4,7 +4,6 @@
   <size memory="1M"/>
 
   <custom>
-    <numeric name="task_transition" data="0" />
     <numeric name="agent_planner" data="0" />
     <numeric name="agent_horizon" data="0.35" />
     <numeric name="agent_timestep" data="0.01" />

--- a/mjpc/tasks/quadruped/task_flat.xml
+++ b/mjpc/tasks/quadruped/task_flat.xml
@@ -4,8 +4,6 @@
   <size memory="1M"/>
 
   <custom>
-    <numeric name="task_reset" data="0" />
-    <numeric name="task_risk" data="0.0" />
     <numeric name="task_transition" data="0" />
     <numeric name="agent_planner" data="0" />
     <numeric name="agent_horizon" data="0.35" />

--- a/mjpc/tasks/quadruped/task_hill.xml
+++ b/mjpc/tasks/quadruped/task_hill.xml
@@ -1,10 +1,10 @@
 <mujoco model="Quadruped Terrain">
   <include file="../common.xml"/>
 
-  <size memory="1M"/>
+  <size memory="1M" nuserdata="1"/>
 
   <custom>
-    <numeric name="task_transition" data="1" />
+    <text name="task_transition" data="Loop|Stage1|Stage2|Stage3|Stage4|Stage5|Stage6|Stage7|Stage8|Stage9|Stage10|Stage11|Stage12|Stage13|Stage14|Stage15|Stage16|Stage17|Stage18|Stage19" />
     <numeric name="agent_planner" data="0" />
     <numeric name="agent_horizon" data="0.25" />
     <numeric name="agent_timestep" data="0.01" />

--- a/mjpc/tasks/swimmer/swimmer.cc
+++ b/mjpc/tasks/swimmer/swimmer.cc
@@ -42,8 +42,7 @@ void Swimmer::Residual(const double* parameters, const mjModel* model,
 //   If swimmer is within tolerance of goal ->
 //   move goal randomly.
 // ---------------------------------------------
-int Swimmer::Transition(int state, const mjModel* model, mjData* data,
-                        Task* task) {
+void Swimmer::Transition(const mjModel* model, mjData* data, Task* task) {
   double* target = mjpc::SensorByName(model, data, "target");
   double* nose = mjpc::SensorByName(model, data, "nose");
   double nose_to_target[2];
@@ -53,6 +52,6 @@ int Swimmer::Transition(int state, const mjModel* model, mjData* data,
     data->mocap_pos[0] = absl::Uniform<double>(gen_, -.8, .8);
     data->mocap_pos[1] = absl::Uniform<double>(gen_, -.8, .8);
   }
-  return state;
 }
+
 }  // namespace mjpc

--- a/mjpc/tasks/swimmer/swimmer.h
+++ b/mjpc/tasks/swimmer/swimmer.h
@@ -32,8 +32,7 @@ static void Residual(const double* parameters, const mjModel* model,
 //   If swimmer is within tolerance of goal ->
 //   move goal randomly.
 // ---------------------------------------------
-static int Transition(int state, const mjModel* model, mjData* data,
-                      Task* task);
+static void Transition(const mjModel* model, mjData* data, Task* task);
 };
 }  // namespace mjpc
 

--- a/mjpc/tasks/swimmer/task.xml
+++ b/mjpc/tasks/swimmer/task.xml
@@ -3,7 +3,7 @@
   <include file="swimmer.xml" />
 
   <custom>
-    <numeric name="task_transition" data="1" />
+    <text name="task_transition" data="1" />
     <numeric name="agent_planner" data="2" />
     <numeric name="agent_horizon" data="2" />
     <numeric name="agent_timestep" data="0.01" />

--- a/mjpc/tasks/swimmer/task.xml
+++ b/mjpc/tasks/swimmer/task.xml
@@ -3,7 +3,6 @@
   <include file="swimmer.xml" />
 
   <custom>
-    <text name="task_transition" data="1" />
     <numeric name="agent_planner" data="2" />
     <numeric name="agent_horizon" data="2" />
     <numeric name="agent_timestep" data="0.01" />

--- a/mjpc/test/agent/rollout_test.cc
+++ b/mjpc/test/agent/rollout_test.cc
@@ -99,7 +99,7 @@ TEST(RolloutTest, Particle) {
   mju_copy(mocap + 3, data->mocap_quat, 4);
 
   // rollout feedback policy
-  trajectory.Rollout(feedback_policy, &task, model, data, state, time, mocap,
+  trajectory.Rollout(feedback_policy, &task, model, data, state, time, mocap, NULL,
                      horizon);
 
   // test final state

--- a/mjpc/test/tasks/task_test.cc
+++ b/mjpc/test/tasks/task_test.cc
@@ -36,8 +36,7 @@ TEST(TasksTest, Task) {
 
   // test task
   EXPECT_NEAR(task.risk, 1.0, 1.0e-5);
-  EXPECT_EQ(task.transition_state, 0);
-  EXPECT_EQ(task.transition_status, 0);
+  EXPECT_EQ(task.transition_stage, 0);
   EXPECT_EQ(task.residual_parameters.size(), 2);
   EXPECT_NEAR(task.residual_parameters[0], 0.05, 1.0e-5);
   EXPECT_NEAR(task.residual_parameters[1], -0.1, 1.0e-5);

--- a/mjpc/trajectory.cc
+++ b/mjpc/trajectory.cc
@@ -85,7 +85,7 @@ void Trajectory::Rollout(
     std::function<void(double* action, const double* state, double time)>
         policy,
     const Task* task, const mjModel* model, mjData* data, const double* state,
-    double time, const double* mocap, int steps) {
+    double time, const double* mocap, const double* userdata, int steps) {
   // reset failure flag
   failure = false;
 
@@ -95,6 +95,7 @@ void Trajectory::Rollout(
   int na = model->na;
   int nu = model->nu;
   int nmocap = model->nmocap;
+  int nuserdata = model->nuserdata;
 
   // horizon
   horizon = steps;
@@ -104,6 +105,9 @@ void Trajectory::Rollout(
     mju_copy(data->mocap_pos + 3 * i, mocap + 7 * i, 3);
     mju_copy(data->mocap_quat + 4 * i, mocap + 7 * i + 3, 4);
   }
+
+  // set userdata 
+  mju_copy(data->userdata, userdata, nuserdata);
 
   // set initial state
   mju_copy(states.data(), state, dim_state);
@@ -180,7 +184,7 @@ void Trajectory::RolloutDiscrete(
     std::function<void(double* action, const double* state, int index)>
         policy,
     const Task* task, const mjModel* model, mjData* data, const double* state,
-    double time, const double* mocap, int steps) {
+    double time, const double* mocap, const double* userdata, int steps) {
   // reset failure flag
   failure = false;
 
@@ -190,6 +194,7 @@ void Trajectory::RolloutDiscrete(
   int na = model->na;
   int nu = model->nu;
   int nmocap = model->nmocap;
+  int nuserdata = model->nuserdata;
 
   // horizon
   horizon = steps;
@@ -199,6 +204,9 @@ void Trajectory::RolloutDiscrete(
     mju_copy(data->mocap_pos + 3 * i, mocap + 7 * i, 3);
     mju_copy(data->mocap_quat + 4 * i, mocap + 7 * i + 3, 4);
   }
+
+  // set userdata 
+  mju_copy(data->userdata, userdata, nuserdata);
 
   // set initial state
   mju_copy(states.data(), state, dim_state);

--- a/mjpc/trajectory.h
+++ b/mjpc/trajectory.h
@@ -52,14 +52,14 @@ class Trajectory {
       std::function<void(double* action, const double* state, double time)>
           policy,
       const Task* task, const mjModel* model, mjData* data, const double* state,
-      double time, const double* mocap, int steps);
+      double time, const double* mocap, const double* userdata, int steps);
 
   // simulate model forward in time with discrete-time indexed policy
   void RolloutDiscrete(
       std::function<void(double* action, const double* state, int index)>
           policy,
       const Task* task, const mjModel* model, mjData* data, const double* state,
-      double time, const double* mocap, int steps);
+      double time, const double* mocap, const double* userdata, int steps);
 
   // ----- members ----- //
   int horizon;                   // trajectory length

--- a/mjpc/utilities.cc
+++ b/mjpc/utilities.cc
@@ -73,6 +73,16 @@ double* GetCustomNumericData(const mjModel* m, std::string_view name) {
   return nullptr;
 }
 
+// get text data from custom using string
+char* GetCustomTextData(const mjModel* m, std::string_view name) {
+  for (int i = 0; i < m->ntextdata; i++) {
+    if (std::string_view(m->names + m->name_textadr[i]) == name) {
+      return m->text_data + m->text_adr[i];
+    }
+  }
+  return nullptr;
+}
+
 // Clamp x between bounds, e.g., bounds[0] <= x[i] <= bounds[1]
 void Clamp(double* x, const double* bounds, int n) {
   for (int i = 0; i < n; i++) {

--- a/mjpc/utilities.h
+++ b/mjpc/utilities.h
@@ -39,6 +39,9 @@ void GetState(const mjModel* model, const mjData* data, double* state);
 // get numerical data from a custom element in mjModel with the given name
 double* GetCustomNumericData(const mjModel* m, std::string_view name);
 
+// get text data from a custom element in mjModel with the given name
+char* GetCustomTextData(const mjModel* m, std::string_view name);
+
 // get a scalar value from a custom element in mjModel with the given name
 template <typename T>
 std::optional<T> GetNumber(const mjModel* m, std::string_view name) {


### PR DESCRIPTION
Custom buttons can be added to the transition GUI and userdata is set before a rollout.  Additionally:

- Updated docs
- Transition works without needing to specify `task_transition` as a custom numeric in a task xml.
- Removed `state` input and return from Transition. This functionality can now be achieved with userdata (see Quadruped Hill or Quadrotor examples)