### PR TITLE
Clean ILQG planner's `RiccatiStep` error handling

### DIFF
--- a/mjpc/planners/ilqg/backward_pass.h
+++ b/mjpc/planners/ilqg/backward_pass.h
@@ -25,6 +25,15 @@
 
 namespace mjpc {
 
+enum RiccatiStepStatusCode {
+  OK, ERROR
+};
+
+struct RiccatiStepStatus {
+  RiccatiStepStatusCode status;
+  std::string message;
+};
+
 enum BackwardPassRegularization : int {
   kControlRegularization = 0,
   kStateControlRegularization,
@@ -48,14 +57,14 @@ class iLQGBackwardPass {
   void Reset(int dim_dstate, int dim_action, int T);
 
   // Riccati at one time step
-  int RiccatiStep(int n, int m, double mu, const double *Wx, const double *Wxx,
-                  const double *At, const double *Bt, const double *cxt,
-                  const double *cut, const double *cxxt, const double *cxut,
-                  const double *cuut, double *Vxt, double *Vxxt, double *dut,
-                  double *Kt, double *dV, double *Qxt, double *Qut,
-                  double *Qxxt, double *Qxut, double *Quut, double *scratch,
-                  BoxQP &boxqp, const double *action,
-                  const double *action_limits, int reg_type, int limits);
+  RiccatiStepStatus RiccatiStep(int n, int m, double mu, const double *Wx, const double *Wxx,
+                                const double *At, const double *Bt, const double *cxt,
+                                const double *cut, const double *cxxt, const double *cxut,
+                                const double *cuut, double *Vxt, double *Vxxt, double *dut,
+                                double *Kt, double *dV, double *Qxt, double *Qut,
+                                double *Qxxt, double *Qxut, double *Quut, double *scratch,
+                                BoxQP &boxqp, const double *action,
+                                const double *action_limits, int reg_type, int limits);
 
   // compute backward pass using Riccati
   int Riccati(iLQGPolicy *p, const ModelDerivatives *md,


### PR DESCRIPTION
@yuvaltassa and I discussed offline that ILQG's backward pass error handling is not super useful right now. In order to improve that, I proposed to fix this with the changes in this PR.

However, while looking at this, we noticed that there is a bigger problem (not just related to the error messaging) of the ILQG backward pass error handling. Based on Yuval's quick look, it appears that the potential error (i.e. the timestep `t` when `t > 0`) coming from `backward_pass.Riccati`
https://github.com/deepmind/mujoco_mpc/blob/66934a8a248bf25f63c8afad0cb61752e9474298/mjpc/planners/ilqg/planner.cc#L228-L232
 should be propagated to `backward_pass.UpdateRegularization`
https://github.com/deepmind/mujoco_mpc/blob/66934a8a248bf25f63c8afad0cb61752e9474298/mjpc/planners/ilqg/planner.cc#L293-L295
which we are not doing right now. This might explain the weird errors we were seeing in the ILQG planner earlier.

@thowell do you have any thoughts on this?

