### PR TITLE
Python API cleanups

### DIFF
--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -1,4 +1,4 @@
-# Predictive Control
+# Usage
 
 **Table of Contents**
 
@@ -292,3 +292,16 @@ This includes:
 - mocap: `data->mocap`
 - userdata: `data->userdata`
 - time: `data->time`
+
+# Python API
+
+We provide a simple Python API for MJPC. This API is still experimental and expects some more experience from its users. For example, the correct usage requires that the model (defined in Python) and the MJPC task (i.e. the residual and transition functions defined in C++) are compatible with each other. Currently, the Python API does not provide any particular error handling for verifying this compatibilty and may be difficult to debug without more in-depth knowedge about mujoco and MJPC.
+
+## Installing via Pip
+The MJPC Python module can be installed with:
+```sh
+pip install "${MUJOCO_MPC_ROOT}/python"
+```
+
+## Example Usage
+See [agent_test.py](../python/mujoco_mpc/agent_test.py) for example usage.

--- a/python/mujoco_mpc/agent.py
+++ b/python/mujoco_mpc/agent.py
@@ -83,7 +83,7 @@ class Agent:
       self,
       task_id: str,
       model: Optional[mujoco.MjModel] = None,
-      send_as: Literal["mjb", "xml"] = "mjb",
+      send_as: Literal["mjb", "xml"] = "xml",
   ):
     """Initialize the agent for task `task_id`.
 

--- a/python/mujoco_mpc/agent.py
+++ b/python/mujoco_mpc/agent.py
@@ -27,9 +27,9 @@ import mujoco
 import numpy as np
 from numpy import typing as npt
 
-# INTERNAL IMPORT
-from mujoco_mpc import agent_pb2
-from mujoco_mpc import agent_pb2_grpc
+import pathlib
+from mujoco_mpc.proto import agent_pb2
+from mujoco_mpc.proto import agent_pb2_grpc
 
 
 def find_free_port() -> int:

--- a/python/setup.py
+++ b/python/setup.py
@@ -216,6 +216,9 @@ class BuildCMakeExtension(build_ext.build_ext):
       cmake_configure_args.append(
         f"-DCMAKE_OSX_ARCHITECTURES={';'.join(osx_archs)}")
 
+    # TODO(hartikainen): We currently configure the builds into
+    # `mujoco_mpc/build`. This should use `self.build_{temp,lib}` instead, to
+    # isolate the Python builds from the C++ builds.
     print("Configuring CMake with the following arguments:")
     for arg in cmake_configure_args:
       print(f"  {arg}")


### PR DESCRIPTION
This will:
* Clean `setup.py`
  * Replace `install` command with `build_py`, which seems more suitable, especially for generating the `agent_pb2{_grpc}.py` files from `proto`.
  * Add `build_ext` for handling the `agent_service` build. We previously assumed that the user has manually built the `agent_service` binary but after these changes, `setup.py` will handle it for the user, which will make the user experience a bit nicer.
* Document the MJPC Python API in `docs/OVERVIEW.md`
* Set the default `send_as` argument to `"xml"` (instead of `"mjb"`) for `Agent.init`. This is required to make the model serialization work until https://github.com/deepmind/mujoco/pull/801 gets released.