### PR TITLE
Tweak python `setup.py`

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -54,6 +54,8 @@ class GenerateProtoGrpcCommand(setuptools.Command):
     `import [agent_pb2_proto_import]`. The latter would fail because the name is
     meant to be relative but python3 interprets it as an absolute import.
     """
+    # We import here because, if the import is at the top of this file, we
+    # cannot resolve the dependencies without having `grpcio-tools` installed.
     from grpc_tools import protoc  # pylint: disable=import-outside-toplevel
 
     agent_proto_filename = "agent.proto"
@@ -70,6 +72,9 @@ class GenerateProtoGrpcCommand(setuptools.Command):
     shutil.copy(agent_proto_source_path, agent_proto_destination_path)
 
     protoc_command_parts = [
+        # We use `__file__`  as the first argument the same way as is done by
+        # `protoc` when called as `__main__` here:
+        # https://github.com/grpc/grpc/blob/21996c37842035661323c71b9e7040345f0915e2/tools/distrib/python/grpcio_tools/grpc_tools/protoc.py#L172-L173.
         __file__,
         f"-I{build_lib_path}",
         f"--python_out={build_lib_path}",

--- a/python/setup.py
+++ b/python/setup.py
@@ -277,8 +277,8 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     python_requires=">=3.7",
     install_requires=[
-        "grpcio-tools >= 1.53.0",
-        "grpcio >= 1.53.0",
+        "grpcio-tools",
+        "grpcio",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
* Move `protoc` import inside the function. This will enable the environment to collect the dependencies even when `protoc` is not pre-installed.
* Use `protoc.main` instead of `process.spawn` to make sure that the right `protoc` is called (`process.spawn` might use different environment). I previously had problems with `protoc.main` on my macos but adding `__file__` as the first argument makes it work both on ubuntu and macos. Adding `__file__` is similar to what is done by `protoc` when called as `__main__` here: https://github.com/grpc/grpc/blob/21996c37842035661323c71b9e7040345f0915e2/tools/distrib/python/grpcio_tools/grpc_tools/protoc.py#L172-L173.
* Raise an error when `protoc`-command fails. This previously failed silently.
* Loosen up the `grpc` dependencies. I think the features that we need from grpc are quite basic and there shouldn't be a need to pin the version very high. I ran into issues with the pinned version when running in an environment with older `tensorflow==2.8.0`.

