### PR TITLE
Move grpc service behind `MJPC_BUILD_GRPC_SERVICE ` flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,11 +18,13 @@ jobs:
               -G Ninja
               -DCMAKE_C_COMPILER:STRING=clang-14
               -DCMAKE_CXX_COMPILER:STRING=clang++-14
+              -DMJPC_BUILD_GRPC_SERVICE:BOOL=ON
             additional_targets: "agent_server"
             tmpdir: "/tmp"
           - os: macos-12
             cmake_args: >-
               -G Ninja
+              -DMJPC_BUILD_GRPC_SERVICE:BOOL=ON
             additional_targets: "agent_server"
             tmpdir: "/tmp"
           - os: windows-2022
@@ -30,6 +32,7 @@ jobs:
               -G Ninja
               -DCMAKE_C_COMPILER:STRING=clang
               -DCMAKE_CXX_COMPILER:STRING=clang++
+              -DMJPC_BUILD_GRPC_SERVICE:BOOL=ON
             tmpdir: "C:/Temp"
 
     name: "MuJoCo MPC on ${{ matrix.os }} ${{ matrix.additional_label }}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ include(MujocoMacOS)
 
 option(MJPC_BUILD_TESTS "Build tests for MJPC" ON)
 option(MJPC_GRPC_BUILD_TESTS "Build tests for gRPC" ON)
+option(MJPC_BUILD_GRPC_SERVICE "Build MJPC gRPC service." OFF)
 option(PYMJPC_BUILD_TESTS "Build tests for Python bindings" ON)
 
 include(FindOrFetch)
@@ -190,4 +191,6 @@ set(MJPC_COMPILE_OPTIONS "${AVX_COMPILE_OPTIONS}" "${EXTRA_COMPILE_OPTIONS}")
 set(MJPC_LINK_OPTIONS "${EXTRA_LINK_OPTIONS}")
 
 add_subdirectory(mjpc)
-add_subdirectory(grpc)
+if(MJPC_BUILD_GRPC_SERVICE)
+  add_subdirectory(grpc)
+endif()

--- a/python/setup.py
+++ b/python/setup.py
@@ -208,7 +208,8 @@ class BuildCMakeExtension(build_ext.build_ext):
     cmake_configure_args = [
         "-DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE",
         f"-DCMAKE_BUILD_TYPE:STRING={build_cfg}",
-        "-DBUILD_TESTING:BOOL=OFF"
+        "-DBUILD_TESTING:BOOL=OFF",
+        "-DMJPC_BUILD_GRPC_SERVICE:BOOL=ON",
     ]
 
     if platform.system() == "Darwin" and "ARCHFLAGS" in os.environ:


### PR DESCRIPTION
The grpc service builds take quite a bit of time which can be annoying if the user only wants to build the default MJPC application. This PR adds an `MJPC_BUILD_GRPC_SERVICE`-option to the cmake build, enabling the control of the grpc/agent service builds: the grpc service is *disabled by default*, and the user can enable it by passing `DMJPC_BUILD_GRPC_SERVICE:BOOL=ON`-flag to the cmake configuration. This flag is also enabled in `setup.py` because the python api depends on the grpc service.

This reduces the `build`-folder size from 4.6G (`MJPC_BUILD_GRPC_SERVICE=ON`) to 871M (`MJPC_BUILD_GRPC_SERVICE=OFF`),