### PR TITLE
Use subtreeangmom sensor instead of subtreelinvel

### DIFF
--- a/mjpc/tasks/quadruped/task_flat.xml
+++ b/mjpc/tasks/quadruped/task_flat.xml
@@ -99,7 +99,7 @@
     <framepos      name="trace0" objtype="site" objname="head"/>
     <subtreecom    name="torso_subtreecom" body="trunk"/>
     <subtreelinvel name="torso_subtreelinvel" body="trunk"/>
-    <subtreeangmom name="torso_angmom" body="trunk"/>
+    <subtreeangmom name="torso_angmom" body="trunk"/> 
   </sensor>
 
   <keyframe>

--- a/mjpc/tasks/quadruped/task_flat.xml
+++ b/mjpc/tasks/quadruped/task_flat.xml
@@ -99,7 +99,7 @@
     <framepos      name="trace0" objtype="site" objname="head"/>
     <subtreecom    name="torso_subtreecom" body="trunk"/>
     <subtreelinvel name="torso_subtreelinvel" body="trunk"/>
-    <subtreelinvel name="torso_angmom" body="trunk"/>
+    <subtreeangmom name="torso_angmom" body="trunk"/>
   </sensor>
 
   <keyframe>


### PR DESCRIPTION
A subtreelinvel was mistakenly being used instead of the subtreeangmom as the name of the sensor would sugest