### PR TITLE
Expose batch estimator sensor info to Python API

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,13 +19,13 @@ jobs:
               -DCMAKE_C_COMPILER:STRING=clang-14
               -DCMAKE_CXX_COMPILER:STRING=clang++-14
               -DMJPC_BUILD_GRPC_SERVICE:BOOL=ON
-            additional_targets: "agent_server"
+            additional_targets: "agent_server batch_server"
             tmpdir: "/tmp"
           - os: macos-12
             cmake_args: >-
               -G Ninja
               -DMJPC_BUILD_GRPC_SERVICE:BOOL=ON
-            additional_targets: "agent_server"
+            additional_targets: "agent_server batch_server"
             tmpdir: "/tmp"
           - os: windows-2022
             cmake_args: >-

--- a/grpc/batch.proto
+++ b/grpc/batch.proto
@@ -266,6 +266,7 @@ message SensorInfoRequest {}
 
 message SensorInfoResponse {
   int32 start_index = 1;
-  int32 measurement_dimension = 2;
+  int32 num_measurements = 2;
+  int32 dim_measurements = 3;
 }
 

--- a/grpc/batch.proto
+++ b/grpc/batch.proto
@@ -41,6 +41,8 @@ service Batch {
   rpc Timing(TimingRequest) returns (TimingResponse);
   // Batch prior matrix
   rpc PriorWeights(PriorWeightsRequest) returns (PriorWeightsResponse);
+  // Sensor dimension info
+  rpc SensorInfo(SensorInfoRequest) returns (SensorInfoResponse);
 }
 
 message MjModel {
@@ -259,3 +261,11 @@ message PriorWeightsResponse {
   repeated double weights = 1 [packed = true];
   int32 dimension = 2;
 }
+
+message SensorInfoRequest {}
+
+message SensorInfoResponse {
+  int32 start_index = 1;
+  int32 measurement_dimension = 2;
+}
+

--- a/grpc/batch_service.cc
+++ b/grpc/batch_service.cc
@@ -35,31 +35,6 @@
 
 namespace mjpc::batch_grpc {
 
-// using ::batch::CostRequest;
-// using ::batch::CostResponse;
-// using ::batch::DataRequest;
-// using ::batch::DataResponse;
-// using ::batch::InitRequest;
-// using ::batch::InitResponse;
-// using ::batch::NoiseRequest;
-// using ::batch::NoiseResponse;
-// using ::batch::NormRequest;
-// using ::batch::NormResponse;
-// using ::batch::OptimizeRequest;
-// using ::batch::OptimizeResponse;
-// using ::batch::PriorWeightsRequest;
-// using ::batch::PriorWeightsResponse;
-// using ::batch::ResetRequest;
-// using ::batch::ResetResponse;
-// using ::batch::SettingsRequest;
-// using ::batch::SettingsResponse;
-// using ::batch::ShiftRequest;
-// using ::batch::ShiftResponse;
-// using ::batch::StatusRequest;
-// using ::batch::StatusResponse;
-// using ::batch::TimingRequest;
-// using ::batch::TimingResponse;
-
 // TODO(taylor): make CheckSize utility function for agent and batch
 namespace {
 absl::Status CheckSize(std::string_view name, int model_size, int vector_size) {
@@ -885,8 +860,11 @@ grpc::Status BatchService::SensorInfo(grpc::ServerContext* context,
   // start index
   response->set_start_index(batch_.SensorStartIndex());
 
+  // number of sensor measurements
+  response->set_num_measurements(batch_.NumberSensors());
+
   // sensor measurement dimension
-  response->set_measurement_dimension(batch_.DimensionSensor());
+  response->set_dim_measurements(batch_.DimensionSensor());
 
   return grpc::Status::OK;
 }

--- a/grpc/batch_service.cc
+++ b/grpc/batch_service.cc
@@ -875,6 +875,22 @@ grpc::Status BatchService::PriorWeights(
   return grpc::Status::OK;
 }
 
+grpc::Status BatchService::SensorInfo(grpc::ServerContext* context,
+                                      const batch::SensorInfoRequest* request,
+                                      batch::SensorInfoResponse* response) {
+  if (!Initialized()) {
+    return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
+  }
+
+  // start index
+  response->set_start_index(batch_.SensorStartIndex());
+
+  // sensor measurement dimension
+  response->set_measurement_dimension(batch_.DimensionSensor());
+
+  return grpc::Status::OK;
+}
+
 #undef CHECK_SIZE
 
 }  // namespace mjpc::batch_grpc

--- a/grpc/batch_service.h
+++ b/grpc/batch_service.h
@@ -85,6 +85,10 @@ class BatchService final : public batch::Batch::Service {
                             const batch::PriorWeightsRequest* request,
                             batch::PriorWeightsResponse* response) override;
 
+  grpc::Status SensorInfo(grpc::ServerContext* context,
+                          const batch::SensorInfoRequest* request,
+                          batch::SensorInfoResponse* response) override;
+
  private:
   bool Initialized() const {
     return batch_.model && batch_.ConfigurationLength() >= 3;

--- a/mjpc/estimators/batch.h
+++ b/mjpc/estimators/batch.h
@@ -125,7 +125,7 @@ class Batch : public Estimator {
   // process dimension
   int DimensionProcess() const override { return ndstate_; };
 
-  // sensor dimensino
+  // sensor dimension
   int DimensionSensor() const override { return nsensordata_; };
 
   // set state

--- a/python/mujoco_mpc/batch.py
+++ b/python/mujoco_mpc/batch.py
@@ -77,7 +77,7 @@ class Batch:
         [str(server_binary_path), f"--mjpc_port={self.port}"],
         stdout=subprocess.PIPE if colab_logging else None,
     )
-    # os.set_blocking(self.server_process.stdout.fileno(), False)
+    os.set_blocking(self.server_process.stdout.fileno(), False)
     atexit.register(self.server_process.kill)
 
     credentials = grpc.local_channel_credentials(
@@ -535,11 +535,11 @@ class Batch:
 
   def _wait(self, future):
     """Waits for the future to complete, while printing out subprocess stdout."""
-    # if self._colab_logging:
-    #     while True:
-    # line = self.server_process.stdout.readline()
-    # if line:
-    #     sys.stdout.write(line.decode("utf-8"))
-    # if future.done():
-    #     break
+    if self._colab_logging:
+      while True:
+        line = self.server_process.stdout.readline()
+        if line:
+            sys.stdout.write(line.decode("utf-8"))
+        if future.done():
+            break
     return future.result()

--- a/python/mujoco_mpc/batch.py
+++ b/python/mujoco_mpc/batch.py
@@ -474,8 +474,18 @@ class Batch:
     # return info
     return {
         "start_index": response.start_index,
-        "measurement_dimension": response.measurement_dimension,
+        "num_measurements": response.num_measurements,
+        "dim_measurements": response.dim_measurements,
     }
+  
+  def measurements_from_sensordata(self, data: npt.ArrayLike) -> np.ndarray:
+    # get sensor info
+    info = self.sensor_info()
+
+    # return measurements from sensor data
+    index = info["start_index"]
+    dim = info["dim_measurements"]
+    return data[index:(index + dim)]
 
   def print_cost(self):
     # get costs

--- a/python/mujoco_mpc/batch.py
+++ b/python/mujoco_mpc/batch.py
@@ -464,6 +464,19 @@ class Batch:
     # return prior matrix
     return mat
 
+  def sensor_info(self) -> dict[str | int]:
+    # info request
+    request = batch_pb2.SensorInfoRequest()
+
+    # info response
+    response = self._wait(self.stub.SensorInfo.future(request))
+
+    # return info
+    return {
+        "start_index": response.start_index,
+        "measurement_dimension": response.measurement_dimension,
+    }
+
   def print_cost(self):
     # get costs
     cost = self.cost()

--- a/python/mujoco_mpc/batch_test.py
+++ b/python/mujoco_mpc/batch_test.py
@@ -596,5 +596,27 @@ class BatchTest(absltest.TestCase):
         1.0e-5,
     )
 
+  def test_sensor_info(self):
+    # load model
+    model_path = (
+        pathlib.Path(__file__).parent.parent.parent
+        / "mjpc/test/testdata/estimator/particle/task.xml"
+    )
+    model = mujoco.MjModel.from_xml_path(str(model_path))
+
+    # initialize
+    configuration_length = 5
+    batch = batch_lib.Batch(
+        model=model, configuration_length=configuration_length
+    )
+
+    # get sensor info
+    info = batch.sensor_info()
+
+    # test
+    self.assertTrue(info["start_index"] == 0)
+    self.assertTrue(info["measurement_dimension"] == 4)
+
+
 if __name__ == "__main__":
   absltest.main()

--- a/python/mujoco_mpc/batch_test.py
+++ b/python/mujoco_mpc/batch_test.py
@@ -615,8 +615,8 @@ class BatchTest(absltest.TestCase):
 
     # test
     self.assertTrue(info["start_index"] == 0)
-    self.assertTrue(info["measurement_dimension"] == 4)
-
+    self.assertTrue(info["num_measurements"] == 4)
+    self.assertTrue(info["dim_measurements"] == 4)
 
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
Returns sensor information (used for grabbing a subset of sensordata corresponding to measurements used by estimators). 

Adds batch_server to build.yml for Github testing.